### PR TITLE
[10日目]：高度なSEOとメタ情報

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -19,6 +19,7 @@ const config: GatsbyConfig = {
     `gatsby-plugin-typescript`,
     `gatsby-transformer-sharp`,
     `gatsby-transformer-remark`,
+    `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -43,6 +43,34 @@ const config: GatsbyConfig = {
       options: {
         output: `/sitemap/`,
         createLinkInHead: true,
+        excludes: ["/404", "/404.html", "/dev-404-page"],
+        query: `
+          {
+            allSitePage {
+              nodes {
+                path
+              }
+            }
+            site {
+              siteMetadata {
+                siteUrl
+              }
+            }
+          }
+        `,
+        resolveSiteUrl: ({ site }: any) => site.siteMetadata.siteUrl,
+        resolvePages: ({ allSitePage: { nodes } }: any) => {
+          return nodes.map((node: any) => ({
+            path: node.path,
+            changefreq: "weekly",
+            priority: node.path === "/" ? 1.0 : 0.7,
+          }));
+        },
+        serialize: ({ path, changefreq, priority }: any) => ({
+          url: path,
+          changefreq,
+          priority,
+        }),
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-plugin-image": "^3.15.0",
     "gatsby-plugin-manifest": "^5.15.0",
     "gatsby-plugin-offline": "^6.15.0",
+    "gatsby-plugin-react-helmet": "^6.15.0",
     "gatsby-plugin-react-i18next": "^3.0.1",
     "gatsby-plugin-sass": "^6.15.0",
     "gatsby-plugin-sharp": "^5.15.0",
@@ -37,6 +38,7 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-helmet": "^6.1.0",
     "react-i18next": "^16.0.1",
     "sass": "^1.93.2"
   },
@@ -50,6 +52,7 @@
     "@types/node": "^24.8.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "@types/react-helmet": "^6.1.11",
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
     "babel-jest": "^30.2.0",

--- a/src/components/Seo/Seo.tsx
+++ b/src/components/Seo/Seo.tsx
@@ -9,6 +9,8 @@ export const SEO: React.FC<SEOProps> = ({
   image,
   pathname,
   articleData,
+  lang = "ja",
+  alternateLangs,
 }) => {
   const { site } = useStaticQuery(graphql`
     query {
@@ -70,7 +72,7 @@ export const SEO: React.FC<SEOProps> = ({
       };
 
   return (
-    <Helmet>
+    <Helmet htmlAttributes={{ lang }}>
       <title>{seo.title}</title>
       <meta name="description" content={seo.description} />
       <link rel="canonical" href={seo.url} />
@@ -87,6 +89,16 @@ export const SEO: React.FC<SEOProps> = ({
       <meta name="twitter:image" content={seo.image} />
 
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+
+      {alternateLangs &&
+        alternateLangs.map(({ href, hreflang }) => (
+          <link
+            key={hreflang}
+            rel="alternate"
+            hrefLang={hreflang}
+            href={href}
+          />
+        ))}
     </Helmet>
   );
 };

--- a/src/components/Seo/types/index.ts
+++ b/src/components/Seo/types/index.ts
@@ -7,4 +7,6 @@ export type SEOProps = {
     author?: string;
     datePublished?: string;
   };
+  lang?: string;
+  alternateLangs?: { href: string; hreflang: string }[];
 };

--- a/src/components/Seo/types/index.ts
+++ b/src/components/Seo/types/index.ts
@@ -1,6 +1,10 @@
 export type SEOProps = {
-  title: string;
+  title?: string;
   description?: string;
   image?: string;
   pathname?: string;
+  articleData?: {
+    author?: string;
+    datePublished?: string;
+  };
 };

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,18 +1,29 @@
 import * as React from "react";
 import { PageProps } from "gatsby";
 import { NotFound, SEO } from "../components";
+import { useTranslation } from "gatsby-plugin-react-i18next";
 
 const NotFoundPage: React.FC<PageProps> = () => {
-  return <NotFound />;
+  const { t, i18n } = useTranslation("common");
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+
+  const alternateLangs = [
+    { hreflang: "ja", href: `${siteUrl}/404` },
+    { hreflang: "en", href: `${siteUrl}/en/404` },
+  ];
+
+  return (
+    <>
+      <SEO
+        title={t("404_title") || "404 Page"}
+        description={t("404_description") || "Gatsby サイトの404ページです"}
+        pathname="/404"
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
+      />
+      <NotFound />
+    </>
+  );
 };
 
 export default NotFoundPage;
-
-export const Head = () => (
-  <SEO
-    title="404 Page"
-    description="Gatsby サイトの404ページです"
-    image=""
-    pathname="/404"
-  />
-);

--- a/src/pages/images.tsx
+++ b/src/pages/images.tsx
@@ -6,10 +6,27 @@ import * as styles from "@styles/images.module.scss";
 import { graphql } from "gatsby";
 
 const ImagesPage: React.FC = () => {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
+
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+
+  const alternateLangs = [
+    { hreflang: "ja", href: `${siteUrl}/images` },
+    { hreflang: "en", href: `${siteUrl}/en/images` },
+  ];
 
   return (
     <Layout pageTitle={t("images_page")}>
+      <SEO
+        title={t("images_page")}
+        description={
+          t("images_page_description") || "Gatsby 画像最適化ページです"
+        }
+        pathname="/images"
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
+      />
+
       <div className={styles.container}>
         <h1>{t("images_page")}</h1>
         <StaticImage
@@ -26,20 +43,6 @@ const ImagesPage: React.FC = () => {
 };
 
 export default ImagesPage;
-
-export const Head: React.FC = () => {
-  const { t } = useTranslation("common");
-
-  return (
-    <SEO
-      title={t("images_page")}
-      description={
-        t("images_page_description") || "Gatsby 画像最適化ページです"
-      }
-      pathname="/images"
-    />
-  );
-};
 
 export const query = graphql`
   query {

--- a/src/templates/HomeTemplate/HomeTemplate.tsx
+++ b/src/templates/HomeTemplate/HomeTemplate.tsx
@@ -5,7 +5,14 @@ import { graphql } from "gatsby";
 import * as styles from "./HomeTemplate.module.scss";
 
 const HomeTemplate: React.FC = () => {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
+
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+
+  const alternateLangs = [
+    { hreflang: "ja", href: `${siteUrl}/` },
+    { hreflang: "en", href: `${siteUrl}/en/` },
+  ];
 
   return (
     <Layout>
@@ -13,6 +20,8 @@ const HomeTemplate: React.FC = () => {
         title={t("seo_home_title")}
         description={t("seo_home_description")}
         pathname="/"
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
       />
       <div className={styles.container}>
         <h1 className={styles.intro}>{t("home")}</h1>

--- a/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
+++ b/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
@@ -27,6 +27,7 @@ jest.mock("gatsby-plugin-react-i18next", () => ({
       };
       return translations[key] || key;
     },
+    i18n: { language: "ja" },
   }),
 }));
 

--- a/src/templates/PostTemplate/PostTemplate.tsx
+++ b/src/templates/PostTemplate/PostTemplate.tsx
@@ -27,6 +27,11 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
         title={seoTitle}
         description={seoDescription}
         pathname={`/posts/${post.slug}`}
+        image={"/images/sample.png"}
+        articleData={{
+          author: "tatsu mori",
+          datePublished: new Date(post.date).toISOString(),
+        }}
       />
 
       <article>
@@ -53,7 +58,7 @@ export const query = graphql`
     contentfulGatsbyBlog(slug: { eq: $slug }) {
       title
       slug
-      date(formatString: "YYYY/MM/DD")
+      date(formatString: "YYYY-MM-DDTHH:mm:ssZ")
       body {
         raw
       }

--- a/src/templates/PostTemplate/PostTemplate.tsx
+++ b/src/templates/PostTemplate/PostTemplate.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "gatsby-plugin-react-i18next";
 import * as styles from "./PostTemplate.module.scss";
 
 const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
   const post = data.contentfulGatsbyBlog;
 
   if (!post) {
@@ -21,6 +21,18 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
   const seoTitle = `${post.title} | ${t("site_name")}`;
   const seoDescription = post.body ? post.body.raw.slice(0, 120) : post.title;
 
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+  const alternateLangs = [
+    {
+      hreflang: "ja",
+      href: `${siteUrl}/posts/${post.slug}`,
+    },
+    {
+      hreflang: "en",
+      href: `${siteUrl}/en/posts/${post.slug}`,
+    },
+  ];
+
   return (
     <Layout pageTitle={post.title}>
       <SEO
@@ -32,6 +44,8 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
           author: "tatsu mori",
           datePublished: new Date(post.date).toISOString(),
         }}
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
       />
 
       <article>

--- a/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
+++ b/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
@@ -32,6 +32,7 @@ jest.mock("gatsby-plugin-react-i18next", () => ({
       };
       return translations[key] || key;
     },
+    i18n: { language: "ja" },
   }),
 }));
 

--- a/src/templates/PostsListTemplate/PostsListTemplate.tsx
+++ b/src/templates/PostsListTemplate/PostsListTemplate.tsx
@@ -8,7 +8,7 @@ import * as styles from "./PostsListTemplate.module.scss";
 const PostsListTemplate: React.FC<
   PageProps<AllContentfulPostQuery, PageContext>
 > = ({ data, pageContext }) => {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
 
   const allPosts = data?.allContentfulGatsbyBlog?.nodes ?? [];
   const { currentPage, numPages } = pageContext;
@@ -37,12 +37,34 @@ const PostsListTemplate: React.FC<
   const hasPrev = currentPage > 1;
   const hasNext = currentPage < numPages;
 
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+  const pathname = currentPage === 1 ? `/posts` : `/posts/${currentPage}`;
+
+  const alternateLangs = [
+    {
+      hreflang: "ja",
+      href:
+        currentPage === 1
+          ? `${siteUrl}/posts`
+          : `${siteUrl}/posts/${currentPage}`,
+    },
+    {
+      hreflang: "en",
+      href:
+        currentPage === 1
+          ? `${siteUrl}/en/posts`
+          : `${siteUrl}/en/posts/${currentPage}`,
+    },
+  ];
+
   return (
     <Layout pageTitle={`${t("posts")} - ${t("page")} ${currentPage}`}>
       <SEO
         title={`${t("posts")} - ${t("page")} ${currentPage}`}
         description={t("posts_list_description", { page: currentPage })}
-        pathname={currentPage === 1 ? `/posts` : `/posts/${currentPage}`}
+        pathname={pathname}
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
       />
 
       <div>

--- a/src/templates/TagTemplate/TagTemplate.tsx
+++ b/src/templates/TagTemplate/TagTemplate.tsx
@@ -8,9 +8,16 @@ import * as styles from "./TagTemplate.module.scss";
 const TagTemplate: React.FC<
   PageProps<AllContentfulPostQuery, { tag: string }>
 > = ({ data, pageContext }) => {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
   const posts = data?.allContentfulGatsbyBlog?.nodes ?? [];
   const { tag } = pageContext;
+
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+
+  const alternateLangs = [
+    { hreflang: "ja", href: `${siteUrl}/tags/${tag}` },
+    { hreflang: "en", href: `${siteUrl}/en/tags/${tag}` },
+  ];
 
   return (
     <Layout pageTitle={`${t("tag")}: ${tag}`}>
@@ -18,6 +25,8 @@ const TagTemplate: React.FC<
         title={`${t("tag")}: ${tag} - ${t("posts")}`}
         description={t("tag_posts_description", { tag })}
         pathname={`/tags/${tag}`}
+        lang={i18n.language}
+        alternateLangs={alternateLangs}
       />
 
       <div>

--- a/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
+++ b/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
@@ -35,6 +35,7 @@ jest.mock("gatsby-plugin-react-i18next", () => ({
       };
       return translations[key] || key;
     },
+    i18n: { language: "ja" },
   }),
 }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,13 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.2.tgz#a4cc874797b7ddc9cb180ef0d5dc23f596fc2332"
   integrity sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==
 
+"@types/react-helmet@^6.1.11":
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.11.tgz#8cafcafff38f75361f451563ba7b406b0c5d3907"
+  integrity sha512-0QcdGLddTERotCXo3VFlUSWO3ztraw8nZ6e3zJSgG7apwV5xt+pJUS8ewPBqT4NYB1optGLprNQzFleIY84u/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.0.tgz#8412946e7e1efb0de9bb59b3aa87676d96add385"
@@ -6885,6 +6892,13 @@ gatsby-plugin-page-creator@^5.15.0:
     globby "^11.1.0"
     lodash "^4.17.21"
 
+gatsby-plugin-react-helmet@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-6.15.0.tgz#90d1739a83790d75b44812ac7f5c361bfbf7228f"
+  integrity sha512-mznXJHiRJ8qQ7lROZEmNsmhRNhxMolcJmLlnSVyfqQrik+9sjRbrzdpZtDD3MJA+/UDDtEedXyXcK4F2HorWmQ==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+
 gatsby-plugin-react-i18next@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-react-i18next/-/gatsby-plugin-react-i18next-3.0.1.tgz#efa264e3cd7bc33d2276ae5ec88ba8d1c59e0714"
@@ -10888,7 +10902,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11085,6 +11099,21 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.1.0.tgz#22b86256beb1c5856f08a9a228adb8121dd985f2"
   integrity sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==
 
+react-fast-compare@^3.1.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-i18next@^16.0.1:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-16.0.1.tgz#2839eca4e65914a0a3cb9f4c440c679a91814daa"
@@ -11121,6 +11150,11 @@ react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825:
     acorn "^6.2.1"
     loose-envify "^1.1.0"
     neo-async "^2.6.1"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react@^18.2.0:
   version "18.3.1"


### PR DESCRIPTION
やったこと

- メタ情報管理の強化
  - gatsby-plugin-react-helmet を導入・活用
  - ページごとに柔軟に <title> や <meta> 情報を設定可能に

- OGタグ・Twitterカード・JSON-LD の追加
- Open Graph (OG) タグを追加して SNS でのシェア表示を最適化
- Twitterカード用の meta タグを追加
- JSON-LD 構造化データを追加し、検索エンジンへの情報提供を強化

- サイトマップのSEO最適化
  - サイトマップを整備
  - SEO的に有効な URL 設計・インデックス管理を確認

- PWA 対応とSEOへの影響確認
  - PWA（Progressive Web App）対応を設定・確認
  - オフライン対応や高速表示による SEO への好影響を意識

- 各種コンポーネントやテンプレートのテスト修正
  - useStaticQuery と graphql のモックを修正してテストが正常に動作するよう対応
  - react-helmet のレンダリング確認テストを整備
  - <title>、<meta>、OGタグ、Twitterカード、JSON-LD の内容確認
  - Gatsby のコンパイル時エラーを回避する形でテストを修正