### PR TITLE
[11日目]：動的機能追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' --max-warnings=0"
   },
   "dependencies": {
+    "@contentful/rich-text-plain-text-renderer": "^17.1.5",
+    "disqus-react": "^1.1.7",
     "gatsby": "^5.14.6",
     "gatsby-plugin-alias-imports": "^1.0.5",
     "gatsby-plugin-image": "^3.15.0",

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -48,9 +48,9 @@
   right: 16px;
   z-index: 10;
 
-  a {
+  .languageLink,
+  .activeLanguage {
     text-decoration: none;
-    color: #333;
     font-weight: 500;
     padding: 6px 10px;
     border-radius: 4px;
@@ -61,13 +61,23 @@
     }
   }
 
+  .languageLink {
+    color: #007acc;
+  }
+
+  .activeLanguage {
+    background-color: #007acc;
+    color: white;
+  }
+
   // スマホ（幅 600px 以下）では縦並びにする
   @media (max-width: 600px) {
     flex-direction: column;
     top: 12px;
     right: 12px;
 
-    a {
+    .languageLink,
+    .activeLanguage {
       padding: 8px 12px;
       text-align: center;
     }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -6,10 +6,20 @@ import { LayoutProps } from "./types";
 
 export const Layout: React.FC<LayoutProps> = ({ pageTitle, children }) => {
   const { t } = useTranslation("common");
-  const { language, originalPath, languages } = useI18next();
+  const { language, originalPath } = useI18next();
 
-  // 現在の言語以外のリンク
-  const otherLanguages = languages.filter((lng) => lng !== language);
+  const languages = ["ja", "en"];
+
+  const getPathForLanguage = (lng: string) => {
+    if (lng === "ja") {
+      // デフォルト言語は / に置換
+      const path = originalPath.replace(/^\/en/, "");
+      return path === "/en/" ? "/" : path;
+    } else {
+      // 英語は /en/... の形式
+      return originalPath === "/" ? `/${lng}/` : `/${lng}${originalPath}`;
+    }
+  };
 
   return (
     <div className={styles.container}>
@@ -28,26 +38,18 @@ export const Layout: React.FC<LayoutProps> = ({ pageTitle, children }) => {
           </Link>
         </nav>
 
-        {/* 言語切替リンク */}
+        {/* 言語切替ボタン */}
         <div className={styles.languageSwitcher}>
-          {otherLanguages.map((lng) => {
-            let newPath: string;
+          {languages.map((lng) => {
+            const path = getPathForLanguage(lng);
+            const isActive = lng === language;
 
-            if (lng === "ja") {
-              // デフォルト言語は / に置換
-              newPath = originalPath.replace(/^\/en/, "");
-              if (originalPath === "/en/") newPath = "/";
-            } else {
-              // デフォルト以外の言語は /en/... の形式
-              if (originalPath === "/") {
-                newPath = `/${lng}/`;
-              } else {
-                newPath = `/${lng}${originalPath}`;
-              }
-            }
-
-            return (
-              <Link key={lng} to={newPath}>
+            return isActive ? (
+              <span key={lng} className={styles.activeLanguage}>
+                {lng.toUpperCase()}
+              </span>
+            ) : (
+              <Link key={lng} to={path} className={styles.languageLink}>
                 {lng.toUpperCase()}
               </Link>
             );

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -19,5 +19,13 @@
   "tag": "Tag",
   "tag_posts_description": "Gatsby + Contentful posts related to tag '{{tag}}'",
   "no_posts_for_tag": "No posts found for tag '{{tag}}'.",
-  "back_to_posts": "Back to Posts"
+  "back_to_posts": "Back to Posts",
+  "comments": "Comments",
+  "contact_author": "Contact the Author",
+  "name": "Name",
+  "email": "Email",
+  "message": "Message",
+  "send": "Send",
+  "form_success_message": "Your message has been sent successfully. Thank you!",
+  "form_error_message": "Failed to send your message. Please try again."
 }

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -19,5 +19,13 @@
   "tag": "タグ",
   "tag_posts_description": "Gatsby + Contentful でタグ「{{tag}}」に関連する記事の一覧ページです",
   "no_posts_for_tag": "タグ「{{tag}}」に関連する記事はありません。",
-  "back_to_posts": "記事一覧に戻る"
+  "back_to_posts": "記事一覧に戻る",
+  "comments": "コメント",
+  "contact_author": "作者に問い合わせる",
+  "name": "お名前",
+  "email": "メールアドレス",
+  "message": "メッセージ",
+  "send": "送信",
+  "form_success_message": "送信が完了しました！ありがとうございます。",
+  "form_error_message": "送信に失敗しました。もう一度お試しください。"
 }

--- a/src/templates/PostTemplate/PostTemplate.module.scss
+++ b/src/templates/PostTemplate/PostTemplate.module.scss
@@ -16,4 +16,104 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
+  color: #333;
+}
+
+.comments {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #ddd;
+
+  h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: #333;
+  }
+
+  iframe {
+    border-radius: 6px;
+    width: 100%;
+  }
+}
+
+.form {
+  margin-top: 3rem;
+  padding: 1.5rem;
+  border-radius: 8px;
+  background-color: #fafafa;
+  border: 1px solid #eee;
+
+  h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: #333;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      font-size: 0.875rem;
+      color: #333;
+      gap: 0.25rem;
+    }
+
+    input,
+    textarea {
+      font-size: 0.875rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      transition: border-color 0.2s ease, background-color 0.2s ease,
+        color 0.2s ease;
+      font-family: inherit;
+
+      &:focus {
+        outline: none;
+        border-color: #007acc;
+      }
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 120px;
+    }
+
+    button {
+      align-self: flex-start;
+      background-color: #007acc;
+      color: white;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+
+      &:hover {
+        background-color: #005fa3;
+      }
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .formMessageSuccess {
+    color: green;
+    margin-top: 0.5rem;
+  }
+
+  .formMessageError {
+    color: red;
+    margin-top: 0.5rem;
+  }
 }

--- a/src/templates/PostTemplate/PostTemplate.tsx
+++ b/src/templates/PostTemplate/PostTemplate.tsx
@@ -4,11 +4,16 @@ import { Layout, SEO } from "../../components";
 import { ContentfulPostData } from "../../types";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { useTranslation } from "gatsby-plugin-react-i18next";
+import { DiscussionEmbed } from "disqus-react";
 import * as styles from "./PostTemplate.module.scss";
 
 const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
   const { t, i18n } = useTranslation("common");
   const post = data.contentfulGatsbyBlog;
+
+  const [formStatus, setFormStatus] = React.useState<
+    "idle" | "submitting" | "success" | "error"
+  >("idle");
 
   if (!post) {
     return (
@@ -18,10 +23,11 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
     );
   }
 
+  const siteUrl = "https://my-gatsby-blogs.netlify.app";
+
   const seoTitle = `${post.title} | ${t("site_name")}`;
   const seoDescription = post.body ? post.body.raw.slice(0, 120) : post.title;
 
-  const siteUrl = "https://my-gatsby-blogs.netlify.app";
   const alternateLangs = [
     {
       hreflang: "ja",
@@ -32,6 +38,41 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
       href: `${siteUrl}/en/posts/${post.slug}`,
     },
   ];
+
+  const disqusConfig = {
+    shortname: "disqus",
+    config: {
+      identifier: post.slug,
+      title: post.title,
+      url: `${siteUrl}/posts/${post.slug}`,
+    },
+  };
+
+  // Netlifyフォーム送信処理
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setFormStatus("submitting");
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+
+    try {
+      const response = await fetch("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(formData as any).toString(),
+      });
+
+      if (response.ok) {
+        setFormStatus("success");
+        form.reset();
+      } else {
+        setFormStatus("error");
+      }
+    } catch {
+      setFormStatus("error");
+    }
+  };
 
   return (
     <Layout pageTitle={post.title}>
@@ -61,6 +102,55 @@ const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
           </div>
         )}
       </article>
+
+      {/* コメントセクション */}
+      <section className={styles.comments}>
+        <h2>{t("comments")}</h2>
+        <DiscussionEmbed {...disqusConfig} />
+      </section>
+
+      {/* お問い合わせフォーム */}
+      <section className={styles.form}>
+        <h2>{t("contact_author")}</h2>
+        <form
+          name="contact"
+          method="POST"
+          data-netlify="true"
+          netlify-honeypot="bot-field"
+          onSubmit={handleSubmit}
+        >
+          <input type="hidden" name="form-name" value="contact" />
+          <p hidden>
+            <label>
+              Don’t fill this out: <input name="bot-field" />
+            </label>
+          </p>
+
+          <label>
+            {t("name")}: <input type="text" name="name" required />
+          </label>
+          <label>
+            {t("email")}: <input type="email" name="email" required />
+          </label>
+          <label>
+            {t("message")}: <textarea name="message" required></textarea>
+          </label>
+
+          <button type="submit" disabled={formStatus === "submitting"}>
+            {formStatus === "submitting" ? "Sending..." : t("send")}
+          </button>
+        </form>
+
+        {/* 送信ステータスメッセージ */}
+        {formStatus === "success" && (
+          <p className={styles.formMessageSuccess}>
+            {t("form_success_message")}
+          </p>
+        )}
+        {formStatus === "error" && (
+          <p className={styles.formMessageError}>{t("form_error_message")}</p>
+        )}
+      </section>
     </Layout>
   );
 };
@@ -72,7 +162,7 @@ export const query = graphql`
     contentfulGatsbyBlog(slug: { eq: $slug }) {
       title
       slug
-      date(formatString: "YYYY-MM-DDTHH:mm:ssZ")
+      date(formatString: "YYYY/MM/DD")
       body {
         raw
       }

--- a/src/templates/PostsListTemplate/PostsListTemplate.tsx
+++ b/src/templates/PostsListTemplate/PostsListTemplate.tsx
@@ -4,6 +4,7 @@ import { Layout, SEO, PostCard } from "../../components";
 import { AllContentfulPostQuery, PageContext } from "../../types";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import * as styles from "./PostsListTemplate.module.scss";
+import { documentToPlainTextString } from "@contentful/rich-text-plain-text-renderer";
 
 const PostsListTemplate: React.FC<
   PageProps<AllContentfulPostQuery, PageContext>
@@ -23,13 +24,20 @@ const PostsListTemplate: React.FC<
 
   // 検索とタグフィルタ適用
   const filteredPosts = allPosts.filter((post) => {
-    const matchesSearch = post.title
+    const titleMatch = post.title
       .toLowerCase()
       .includes(searchTerm.toLowerCase());
+
+    const bodyText = post.body?.raw
+      ? documentToPlainTextString(JSON.parse(post.body.raw))
+      : "";
+    const bodyMatch = bodyText.toLowerCase().includes(searchTerm.toLowerCase());
+
     const matchesTag = selectedTag
       ? (post.tags ?? []).includes(selectedTag)
       : true;
-    return matchesSearch && matchesTag;
+
+    return (titleMatch || bodyMatch) && matchesTag;
   });
 
   const prevPage = currentPage === 2 ? `/posts` : `/posts/${currentPage - 1}`;
@@ -125,6 +133,9 @@ export const query = graphql`
         slug
         date(formatString: "YYYY/MM/DD")
         tags
+        body {
+          raw
+        }
       }
     }
     locales: allLocale {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,6 +1129,13 @@
     "@vercel/stega" "^0.1.2"
     json-pointer "^0.6.2"
 
+"@contentful/rich-text-plain-text-renderer@^17.1.5":
+  version "17.1.5"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-17.1.5.tgz#fd6eb6495a6f122e543887a0c1299bd96703f85f"
+  integrity sha512-N3IX2k5Zs93PaI6nnVjCRk+vqfbc1uuYofAnRsniTa3gTj1fkf0FtdjYJOkWsBZjJxhT9y3RI2d9FoLT+a97dQ==
+  dependencies:
+    "@contentful/rich-text-types" "^17.2.4"
+
 "@contentful/rich-text-react-renderer@^15.22.11":
   version "15.22.11"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.22.11.tgz#111859f7278a42c52b8ad1ce9ffc2f877609fc83"
@@ -1140,6 +1147,14 @@
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz#832c8b428612f5181908bc1033c6ef9f48f1ce83"
   integrity sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==
+
+"@contentful/rich-text-types@^17.2.4":
+  version "17.2.4"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz#09ba76364ecf068e3e3a80dd407fdf3d47a283be"
+  integrity sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==
+  dependencies:
+    "@lingui/core" "^5.4.1"
+    is-plain-obj "^3.0.0"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1907,6 +1922,22 @@
   dependencies:
     "@lezer/common" "^1.0.0"
 
+"@lingui/core@^5.4.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-5.5.1.tgz#3d5a8d1bed841074e97ee97f0efbe1a727e812d5"
+  integrity sha512-jxmeLTnKKbnVaLUllHpnM3XolFipHqgr0hQkuAj5+SGTGimaHx6RyGm/YL5FxWeYMt7wRRoH86SIJ3sn44pxAw==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    "@lingui/message-utils" "5.5.1"
+
+"@lingui/message-utils@5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@lingui/message-utils/-/message-utils-5.5.1.tgz#200ad17fa8954b49c41bcc0dab6ef478025662f6"
+  integrity sha512-RV3WjkSDTYIhNQwAj5MUHjpfOgPJFBXDuBW3aFZZmPqAkFrSJJbrKxVmBoja59b3CEX5QuCGOHnijrCehBpU+w==
+  dependencies:
+    "@messageformat/parser" "^5.0.0"
+    js-sha256 "^0.10.1"
+
 "@lmdb/lmdb-darwin-arm64@2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz#bc66fa43286b5c082e8fee0eacc17995806b6fbe"
@@ -1966,6 +1997,13 @@
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz#c72e8b6faae31d925d23a6db0379cc3fe0216fdd"
   integrity sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==
+
+"@messageformat/parser@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@messageformat/parser/-/parser-5.1.1.tgz#ca7d6c18e9f3f6b6bc984a465dac16da00106055"
+  integrity sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==
+  dependencies:
+    moo "^0.5.1"
 
 "@mischnic/json-sourcemap@^0.1.0":
   version "0.1.1"
@@ -5373,6 +5411,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+disqus-react@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.1.7.tgz#b4d5152396f5ee7bca0563784113f522e9d74a44"
+  integrity sha512-O+3q6weESpfCBumz45F+8Ue26zUn7UI62BCYwscoBszSr9vWPJohMiTtZWL/m8AyFba53bsSEhwyJcrTnXDMpg==
+
 dns-packet@^5.2.4:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.6.1.tgz#ae888ad425a9d1478a0674256ab866de1012cf2f"
@@ -8278,6 +8321,11 @@ is-plain-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
 is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -8930,6 +8978,11 @@ joi@^17.11.0, joi@^17.9.2:
     "@sideway/address" "^4.1.5"
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
+
+js-sha256@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.10.1.tgz#b40104ba1368e823fdd5f41b66b104b15a0da60d"
+  integrity sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -9796,6 +9849,11 @@ moment@^2.29.4:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+moo@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
やったこと

- コメント機能（Disqus）
  - disqus-react の DiscussionEmbed を導入
  - 記事ごとに identifier、title、URL を設定
  - JSONファイルで多言語対応のタイトル comments を追加

- クライアントサイド検索（PostsListTemplate.tsx）
  - 記事タイトルおよび本文（plain text）に対して検索フィルタを実装

- お問い合わせフォーム（Netlify Forms連携）
  - フォームを HTML 属性 data-netlify="true" で設定
  - React 内で fetch を使った送信制御（ページリロードなし）
  - 送信ステータス管理 (idle / submitting / success / error)
  - 成功・失敗メッセージを SCSS でスタイリング
  - JSON ファイルにフォーム用ラベルやメッセージを追加

- 言語切り替え
  - JAとENの2つの言語を表示

- 多言語対応（i18n）
  - 日本語版 JSON (ja/common.json) を拡張
  - 英語版 JSON (en/common.json) も追加
  - コメント・フォーム・送信ステータスの文言を追加して多言語対応完了