### PR TITLE
[16日目]：ログイン・ログアウト機能実装

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,3 +1,6 @@
+import { AuthProvider } from "./src/context/AuthContext";
+import React from "react";
+
 declare global {
   interface Window {
     dataLayer: Record<string, any>[];
@@ -19,4 +22,8 @@ export const onRouteUpdate = ({ location }: { location: Location }) => {
   if (process.env.NODE_ENV === "development") {
     console.log("[GTM] page_view sent:", location.pathname);
   }
+};
+
+export const wrapRootElement = ({ element }: { element: React.ReactNode }) => {
+  return <AuthProvider>{element}</AuthProvider>;
 };

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { AuthProvider } from "./src/context/AuthContext";
+
+export const wrapRootElement = ({ element }: { element: React.ReactNode }) => {
+  return <AuthProvider>{element}</AuthProvider>;
+};

--- a/src/components/Dashboard/Dashboard.module.scss
+++ b/src/components/Dashboard/Dashboard.module.scss
@@ -1,0 +1,9 @@
+.container {
+  max-width: 600px;
+  margin: 3rem auto;
+  text-align: center;
+}
+
+.button {
+  margin: 1rem;
+}

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next";
+import { useAuth } from "../../context";
+import * as styles from "./Dashboard.module.scss";
+
+export const Dashboard = () => {
+  const { t } = useTranslation("common");
+  const { user, logout } = useAuth();
+
+  return (
+    <div className={styles.container}>
+      <h1>{t("dashboard")}</h1>
+      {user && (
+        <>
+          <p>
+            {t("loginUser")}
+            {user.email}
+          </p>
+          <button className={styles.button} onClick={logout}>
+            {t("logout")}
+          </button>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/Dashboard/index.ts
+++ b/src/components/Dashboard/index.ts
@@ -1,0 +1,1 @@
+export * from "./Dashboard";

--- a/src/components/Login/hooks/useLogin.ts
+++ b/src/components/Login/hooks/useLogin.ts
@@ -26,7 +26,7 @@ export const useLogin = () => {
 
     try {
       await signInWithEmailAndPassword(auth, email, password);
-      navigate("/");
+      navigate("/dashboard");
     } catch (err: any) {
       switch (err.code) {
         case "auth/invalid-email":

--- a/src/components/PrivateRoute/PrivateRoute.module.scss
+++ b/src/components/PrivateRoute/PrivateRoute.module.scss
@@ -1,0 +1,4 @@
+.container {
+  text-align: center;
+  margin-top: 2rem;
+}

--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import { FC, ReactNode } from "react";
+import { navigate } from "gatsby";
+import { useAuth } from "../../context";
+import * as styles from "./PrivateRoute.module.scss";
+
+export const PrivateRoute: FC<{ children: ReactNode }> = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <p className={styles.container}>読み込み中...</p>;
+  }
+
+  if (!user) {
+    if (typeof window !== "undefined") {
+      navigate("/login");
+    }
+    return null;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/PrivateRoute/index.ts
+++ b/src/components/PrivateRoute/index.ts
@@ -1,0 +1,1 @@
+export * from "./PrivateRoute";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export * from "./Layout";
 export * from "./NotFound";
 export * from "./Seo";
 export * from "./PostCard";
+export * from "./PrivateRoute";

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,78 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  onAuthStateChanged,
+  signOut,
+  getIdToken,
+  type User,
+} from "firebase/auth";
+import { AuthContextType } from "./types";
+import { auth } from "../firebase";
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = (): AuthContextType => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+};
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setLoading(false);
+      return;
+    }
+
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (firebaseUser) => {
+        setUser(firebaseUser);
+        setLoading(false);
+      },
+      (error) => {
+        console.error("onAuthStateChanged error:", error);
+        setUser(null);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, []);
+
+  const logout = async () => {
+    try {
+      await signOut(auth);
+    } catch (e) {
+      console.error("logout failed:", e);
+      throw e;
+    }
+  };
+
+  const refreshIdToken = async (): Promise<string | null> => {
+    if (!auth.currentUser) return null;
+    try {
+      const token = await getIdToken(auth.currentUser, true);
+      return token;
+    } catch (e) {
+      console.error("refreshIdToken failed:", e);
+      return null;
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, logout, refreshIdToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthContext";

--- a/src/context/types/index.ts
+++ b/src/context/types/index.ts
@@ -1,0 +1,8 @@
+import type { User } from "firebase/auth";
+
+export type AuthContextType = {
+  user: User | null;
+  loading: boolean;
+  logout: () => Promise<void>;
+  refreshIdToken: () => Promise<string | null>;
+};

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -39,5 +39,8 @@
   "password": "Password",
   "email_format": "The email address format is incorrect.",
   "email_wrong": "The email address or password is incorrect.",
-  "login_failed": "Login failed."
+  "login_failed": "Login failed.",
+  "dashboard": "Dashboard",
+  "loginUser": "Currently logged-in user:",
+  "logout": "Logout"
 }

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -39,5 +39,8 @@
   "password": "パスワード",
   "email_format": "メールアドレスの形式が正しくありません。",
   "email_wrong": "メールアドレスまたはパスワードが間違っています。",
-  "login_failed": "ログインに失敗しました。"
+  "login_failed": "ログインに失敗しました。",
+  "dashboard": "ダッシュボード",
+  "loginUser": "ログイン中のユーザー：",
+  "logout": "ログアウト"
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { PrivateRoute } from "@components/PrivateRoute";
+import { Dashboard } from "@components/Dashboard";
+import { graphql } from "gatsby";
+
+const DashboardPage: React.FC = () => {
+  return (
+    <PrivateRoute>
+      <Dashboard />
+    </PrivateRoute>
+  );
+};
+
+export default DashboardPage;
+
+export const query = graphql`
+  query {
+    locales: allLocale {
+      edges {
+        node {
+          ns
+          data
+          language
+        }
+      }
+    }
+  }
+`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "commonjs",
     "jsx": "react-jsx",
+    "allowJs": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -21,8 +22,8 @@
     "src",
     "gatsby-config.ts",
     "gatsby-node.ts",
-    "gatsby-browser.ts",
-    "gatsby-ssr.ts"
+    "gatsby-browser.tsx",
+    "gatsby-ssr.tsx"
   ],
   "exclude": ["node_modules", ".cache", "public"]
 }


### PR DESCRIPTION
やったこと

- AuthContext 作成
  - onAuthStateChanged で Firebase ユーザー状態を監視
  - user と loading を管理
  - logout() と refreshIdToken() を提供
  - useAuth() フックでどこからでも簡単にアクセス可能に
  - SSR 対応のため typeof window !== "undefined" チェックを実装

- Gatsby 全体に AuthContext を適用
  - gatsby-browser.tsx / gatsby-ssr.tsx に wrapRootElement を追加
  - Google Tag Manager の onRouteUpdate と共存可能に設定

- PrivateRoute コンポーネント作成
  - 未ログインユーザーは自動で /login にリダイレクト
  - ローディング中は「読み込み中…」を表示
  - ログイン済みユーザーのみ子コンポーネントを表示
  - Dashboard など保護ページに適用

- Dashboardページ作成
  - PrivateRoute でラップ
  - useAuth() でログイン中ユーザーのメールを表示
  - 「ログアウト」ボタンで Firebase からサインアウト → /login に遷移

- ログインフロー・テスト
  - /login で正しいメール・パスワードでログイン → /dashboard に遷移
  - ログアウト → /login に戻る
  - ページリロード → ログイン状態が保持される
  - 未ログイン時に /dashboard へアクセス → /login にリダイレクト
  - 間違った情報でログイン → エラーメッセージ表示
