### PR TITLE
[22日目]：通知連携

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^13.6.0",
-    "firebase-functions": "^6.6.0"
+    "firebase-functions": "^6.6.0",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,6 +20,7 @@ export const helloWorld = onRequest((request, response) => {
 });
 
 export { logError };
+export { notifyOnError } from "./notifyOnError";
 
 admin.initializeApp();
 

--- a/functions/src/notifyOnError.ts
+++ b/functions/src/notifyOnError.ts
@@ -1,0 +1,53 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { setGlobalOptions } from "firebase-functions/v2/options";
+import * as admin from "firebase-admin";
+import fetch from "node-fetch";
+
+setGlobalOptions({ region: "asia-northeast1" });
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const SLACK_WEBHOOK_URL =
+  process.env.SLACK_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL_FALLBACK || "";
+
+export const notifyOnError = onDocumentCreated(
+  "errorLogs/{logId}",
+  async (event) => {
+    const logData = event.data?.data();
+    if (!logData) return;
+
+    const { level, message, page, detail, timestamp } = logData;
+
+    if (level !== "error") return;
+
+    const slackMessage = {
+      text: `🚨 *Error Detected!*\n*Message:* ${message}\n*Page:* ${page}\n*Time:* ${
+        timestamp?.toDate?.() ?? timestamp
+      }\n*Details:* ${detail ?? "N/A"}`,
+    };
+
+    try {
+      if (!SLACK_WEBHOOK_URL) {
+        console.warn("Slack webhook URL not set. Skipping notification.");
+        return;
+      }
+
+      const response = await fetch(SLACK_WEBHOOK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(slackMessage),
+      });
+
+      if (!response.ok) {
+        console.error(
+          "Failed to send Slack notification:",
+          await response.text()
+        );
+      }
+    } catch (error) {
+      console.error("Error sending Slack notification:", error);
+    }
+  }
+);

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -887,6 +887,11 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-view-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz#211a03ba95ecaf7798a8c7198d79536211f88570"
@@ -1418,6 +1423,14 @@ faye-websocket@0.11.4:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -1525,6 +1538,13 @@ form-data@^2.5.5:
     hasown "^2.0.2"
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2383,12 +2403,26 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^1.3.1:
   version "1.3.1"
@@ -3192,6 +3226,11 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/src/components/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/components/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Dashboard } from "../Dashboard";
+import { useAuth } from "../../../context";
+
+jest.mock("../../context", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("Dashboard Component", () => {
+  const mockUseAuth = useAuth as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("🔄 ローディング中の表示", () => {
+    mockUseAuth.mockReturnValue({
+      loading: true,
+      user: null,
+      error: null,
+      logout: jest.fn(),
+    });
+
+    render(<Dashboard />);
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  test("⚠️ エラー表示とリロードボタン動作", () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      user: null,
+      error: "認証エラーが発生しました",
+      logout: jest.fn(),
+    });
+
+    render(<Dashboard />);
+
+    expect(screen.getByText("errorTitle")).toBeInTheDocument();
+    expect(screen.getByText("認証エラーが発生しました")).toBeInTheDocument();
+
+    // reloadボタン動作確認
+    const reloadSpy = jest
+      .spyOn(window.location, "reload")
+      .mockImplementation(() => {});
+    fireEvent.click(screen.getByText("reload"));
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+
+  test("👤 ユーザーがいない場合の表示", () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      user: null,
+      error: null,
+      logout: jest.fn(),
+    });
+
+    render(<Dashboard />);
+    expect(screen.getByText("dashboard")).toBeInTheDocument();
+    expect(screen.getByText("noUser")).toBeInTheDocument();
+  });
+
+  test("✅ ユーザー情報がある場合の表示", () => {
+    const mockLogout = jest.fn();
+    const mockUser = {
+      uid: "user123",
+      email: "test@example.com",
+      metadata: {
+        creationTime: "2024-01-01T10:00:00Z",
+        lastSignInTime: "2024-06-01T15:00:00Z",
+      },
+    };
+
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      user: mockUser,
+      error: null,
+      logout: mockLogout,
+    });
+
+    render(<Dashboard />);
+
+    expect(screen.getByText("dashboard")).toBeInTheDocument();
+    expect(screen.getByText("UID:")).toBeInTheDocument();
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    expect(screen.getByText("logout")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("logout"));
+    expect(mockLogout).toHaveBeenCalled();
+  });
+});

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -34,6 +34,9 @@ export const Header: React.FC = () => {
               <Link to="/posts" className={styles.link}>
                 {t("posts")}
               </Link>
+              <Link to="/error-logs" className={styles.link}>
+                {t("errorLogs")}
+              </Link>
               <Link to="/settings" className={styles.link}>
                 {t("settings")}
               </Link>

--- a/src/components/NotificationSettings/NotificationSettings.module.scss
+++ b/src/components/NotificationSettings/NotificationSettings.module.scss
@@ -1,0 +1,36 @@
+.loading {
+  text-align: center;
+  margin: 1rem;
+  font-size: 24px;
+}
+
+.container {
+  padding: 24px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.description {
+  color: #555;
+  margin-bottom: 20px;
+}
+
+.checkboxGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+}

--- a/src/components/NotificationSettings/NotificationSettings.tsx
+++ b/src/components/NotificationSettings/NotificationSettings.tsx
@@ -1,0 +1,31 @@
+import { useNotificationSettings } from "./hooks";
+import * as styles from "./NotificationSettings.module.scss";
+import { useTranslation } from "react-i18next";
+
+export const NotificationSettings = () => {
+  const { t } = useTranslation("common");
+  const { settings, loading, handleChange, updateSettings } =
+    useNotificationSettings();
+
+  if (loading) return <div className={styles.loading}>{t("loading")}</div>;
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>{t("errorNotificationSettings")}</h1>
+      <p className={styles.description}>{t("selectErrorLevelsToNotify")}</p>
+
+      <div className={styles.checkboxGroup}>
+        {["error", "warning", "info"].map((level) => (
+          <label key={level} className={styles.checkboxLabel}>
+            <input
+              type="checkbox"
+              checked={settings.notificationLevel.includes(level)}
+              onChange={() => handleChange(level)}
+            />
+            {t(level)}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/NotificationSettings/hooks/index.ts
+++ b/src/components/NotificationSettings/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useNotificationSettings";

--- a/src/components/NotificationSettings/hooks/useNotificationSettings.ts
+++ b/src/components/NotificationSettings/hooks/useNotificationSettings.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { db } from "../../../firebase";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+
+const USER_ID = "testUser";
+
+export const useNotificationSettings = () => {
+  const [settings, setSettings] = useState({
+    notificationLevel: [] as string[],
+  });
+  const [loading, setLoading] = useState(true);
+
+  const fetchSettings = async () => {
+    try {
+      const ref = doc(db, "userSettings", USER_ID);
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setSettings(snap.data() as any);
+      } else {
+        await setDoc(ref, { notificationLevel: ["error"] });
+        setSettings({ notificationLevel: ["error"] });
+      }
+    } catch (error) {
+      console.error("Error fetching settings:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateSettings = async (levels: string[]) => {
+    try {
+      const ref = doc(db, "userSettings", USER_ID);
+      await setDoc(ref, { notificationLevel: levels }, { merge: true });
+      setSettings((prev) => ({ ...prev, notificationLevel: levels }));
+    } catch (error) {
+      console.error("Error updating settings:", error);
+    }
+  };
+
+  const handleChange = (level: string) => {
+    const newLevels = settings.notificationLevel.includes(level)
+      ? settings.notificationLevel.filter((l) => l !== level)
+      : [...settings.notificationLevel, level];
+    updateSettings(newLevels);
+  };
+
+  useEffect(() => {
+    fetchSettings();
+  }, []);
+
+  return { settings, loading, updateSettings, handleChange };
+};

--- a/src/components/NotificationSettings/index.ts
+++ b/src/components/NotificationSettings/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotificationSettings";

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -107,5 +107,7 @@
   "all": "All",
   "error": "Error",
   "warning": "Warning",
-  "info": "Info"
+  "info": "Info",
+  "errorNotificationSettings": "Error Log Notification Settings",
+  "selectErrorLevelsToNotify": "Select the error levels you wish to receive notifications for"
 }

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -107,5 +107,7 @@
   "all": "すべて",
   "error": "エラー",
   "warning": "警告",
-  "info": "情報"
+  "info": "情報",
+  "errorNotificationSettings": "エラーログ通知設定",
+  "selectErrorLevelsToNotify": "通知を受け取りたいエラーレベルを選択してください"
 }

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -1,0 +1,27 @@
+import { graphql } from "gatsby";
+import { Layout } from "@components/Layout";
+import { NotificationSettings } from "@components/NotificationSettings";
+
+const NotificationsPage = () => {
+  return (
+    <Layout>
+      <NotificationSettings />
+    </Layout>
+  );
+};
+
+export default NotificationsPage;
+
+export const query = graphql`
+  query {
+    locales: allLocale {
+      edges {
+        node {
+          ns
+          data
+          language
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
やったこと

- 通知機能の目的整理
  - Firestore に新しいエラーログが追加された際、自動で通知を送る仕組みを導入する。

- Slack 通知用 Cloud Function の実装
  - Firestore の errorLogs コレクションをトリガーにして Slack に通知を送る仕組みを追加。

- 環境変数の設定
  - Slack Webhook URLをFirebase Functions に安全に保存
  - .env / 環境変数経由で管理。

- v1 / v2 Functions 構文の違いを理解
  - v1構文：functions.firestore.document("path").onCreate(...)
  - v2構文：onDocumentCreated("path", async (event) => {...})
  - v1構文を使う場合とv2構文を使う場合の修正版をそれぞれ整理・実装。

- Slack通知処理の詳細
  - ログデータ（level, message, page, detail, timestamp）を取得。
  - level が "error" の場合のみ通知を送信。

- 実行確認とデバッグ
  - Firestoreに新規ドキュメントを追加 → Cloud Functionsがトリガーされることを確認。
  - Slackチャンネルに通知メッセージが届くかチェック。
