### PR TITLE
[23日目]：コンポーネントテスト（ユニットテスト）の作成

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,8 +1,9 @@
 import { useTranslation } from "react-i18next";
+import { DashboardProps } from "./types";
 import { useAuth } from "../../context";
 import * as styles from "./Dashboard.module.scss";
 
-export const Dashboard = () => {
+export const Dashboard: React.FC<DashboardProps> = ({ reloadFn }) => {
   const { t } = useTranslation("common");
   const { error, user, logout, loading } = useAuth();
 
@@ -17,7 +18,7 @@ export const Dashboard = () => {
         <p>{error}</p>
         <button
           className={styles.reloadButton}
-          onClick={() => window.location.reload()}
+          onClick={reloadFn || (() => window.location.reload())}
         >
           {t("reload")}
         </button>

--- a/src/components/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/components/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,96 +1,126 @@
+import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { Dashboard } from "../Dashboard";
-import { useAuth } from "../../../context";
 
+// --- i18n モック ---
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        loading: "読み込み中...",
+        errorTitle: "エラーが発生しました",
+        reload: "再読み込み",
+        dashboard: "ダッシュボード",
+        noUser: "ユーザー情報がありません",
+        email: "メールアドレス",
+        createdAt: "作成日時",
+        lastLogin: "最終ログイン",
+        logout: "ログアウト",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+// --- useAuth モック ---
 jest.mock("../../../context", () => ({
   useAuth: jest.fn(),
 }));
 
-jest.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-  }),
-}));
+const { useAuth } = jest.requireMock("../../../context");
 
-describe("Dashboard Component", () => {
-  const mockUseAuth = useAuth as jest.Mock;
-
-  beforeEach(() => {
+describe("Dashboard コンポーネント", () => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("🔄 ローディング中の表示", () => {
-    mockUseAuth.mockReturnValue({
+  it("loading 中はローディングメッセージを表示する", () => {
+    useAuth.mockReturnValue({
       loading: true,
-      user: null,
       error: null,
+      user: null,
+      logout: jest.fn(),
+    });
+    render(<Dashboard />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("エラー時はエラーメッセージと再読み込みボタンを表示する", () => {
+    useAuth.mockReturnValue({
+      loading: false,
+      error: "サーバーエラー",
+      user: null,
       logout: jest.fn(),
     });
 
-    render(<Dashboard />);
-    expect(screen.getByText("loading")).toBeInTheDocument();
+    const reloadMock = jest.fn();
+    render(<Dashboard reloadFn={reloadMock} />); // テスト用関数を注入
+
+    expect(screen.getByText("エラーが発生しました")).toBeInTheDocument();
+    expect(screen.getByText("サーバーエラー")).toBeInTheDocument();
+
+    const reloadButton = screen.getByText("再読み込み");
+    fireEvent.click(reloadButton);
+    expect(reloadMock).toHaveBeenCalled(); // 安全に確認可能
   });
 
-  test("⚠️ エラー表示とリロードボタン動作", () => {
-    mockUseAuth.mockReturnValue({
+  it("未ログイン時はユーザー情報なしメッセージを表示する", () => {
+    useAuth.mockReturnValue({
       loading: false,
-      user: null,
-      error: "認証エラーが発生しました",
-      logout: jest.fn(),
-    });
-
-    render(<Dashboard />);
-
-    expect(screen.getByText("errorTitle")).toBeInTheDocument();
-    expect(screen.getByText("認証エラーが発生しました")).toBeInTheDocument();
-
-    // reloadボタン動作確認
-    const reloadSpy = jest
-      .spyOn(window.location, "reload")
-      .mockImplementation(() => {});
-    fireEvent.click(screen.getByText("reload"));
-    expect(reloadSpy).toHaveBeenCalled();
-  });
-
-  test("👤 ユーザーがいない場合の表示", () => {
-    mockUseAuth.mockReturnValue({
-      loading: false,
-      user: null,
       error: null,
+      user: null,
       logout: jest.fn(),
     });
 
     render(<Dashboard />);
-    expect(screen.getByText("dashboard")).toBeInTheDocument();
-    expect(screen.getByText("noUser")).toBeInTheDocument();
+    expect(screen.getByText("ダッシュボード")).toBeInTheDocument();
+    expect(screen.getByText("ユーザー情報がありません")).toBeInTheDocument();
   });
 
-  test("✅ ユーザー情報がある場合の表示", () => {
+  it("ログイン済み時はユーザー情報とログアウトボタンを表示する", () => {
     const mockLogout = jest.fn();
-    const mockUser = {
-      uid: "user123",
-      email: "test@example.com",
-      metadata: {
-        creationTime: "2024-01-01T10:00:00Z",
-        lastSignInTime: "2024-06-01T15:00:00Z",
-      },
-    };
 
-    mockUseAuth.mockReturnValue({
+    useAuth.mockReturnValue({
       loading: false,
-      user: mockUser,
       error: null,
+      user: {
+        uid: "abc123",
+        email: "test@example.com",
+        metadata: {
+          creationTime: "2025-01-01T00:00:00Z",
+          lastSignInTime: "2025-11-10T00:00:00Z",
+        },
+      },
       logout: mockLogout,
     });
 
     render(<Dashboard />);
 
-    expect(screen.getByText("dashboard")).toBeInTheDocument();
+    expect(screen.getByText("ダッシュボード")).toBeInTheDocument();
     expect(screen.getByText("UID:")).toBeInTheDocument();
+    expect(screen.getByText("abc123")).toBeInTheDocument();
+    expect(screen.getByText("メールアドレス:")).toBeInTheDocument();
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
-    expect(screen.getByText("logout")).toBeInTheDocument();
+    expect(screen.getByText("作成日時:")).toBeInTheDocument();
+    expect(screen.getByText("最終ログイン:")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("logout"));
+    const logoutButton = screen.getByText("ログアウト");
+    fireEvent.click(logoutButton);
     expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it("ユーザーメタデータがない場合は N/A を表示する", () => {
+    useAuth.mockReturnValue({
+      loading: false,
+      error: null,
+      user: { uid: "abc123", email: "test@example.com", metadata: null },
+      logout: jest.fn(),
+    });
+
+    render(<Dashboard />);
+
+    const naElements = screen.getAllByText("N/A");
+    expect(naElements.length).toBe(2);
   });
 });

--- a/src/components/Dashboard/__tests__/Dashboard.test.tsx
+++ b/src/components/Dashboard/__tests__/Dashboard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Dashboard } from "../Dashboard";
 import { useAuth } from "../../../context";
 
-jest.mock("../../context", () => ({
+jest.mock("../../../context", () => ({
   useAuth: jest.fn(),
 }));
 

--- a/src/components/Dashboard/types/index.ts
+++ b/src/components/Dashboard/types/index.ts
@@ -1,0 +1,3 @@
+export type DashboardProps = {
+  reloadFn?: () => void;
+};

--- a/src/components/ErrorLogs/ErrorLogs.tsx
+++ b/src/components/ErrorLogs/ErrorLogs.tsx
@@ -1,6 +1,7 @@
 import * as styles from "./ErrorLogs.module.scss";
 import { useTranslation } from "react-i18next";
 import { useErrorLogs } from "./hooks";
+import { Fragment } from "react";
 
 export const ErrorLogs = () => {
   const { t } = useTranslation("common");
@@ -61,7 +62,7 @@ export const ErrorLogs = () => {
             </thead>
             <tbody>
               {logs.map((log) => (
-                <>
+                <Fragment key={log.id}>
                   <tr
                     key={log.id}
                     className={styles[`level_${log.level ?? "error"}`]}
@@ -94,7 +95,7 @@ export const ErrorLogs = () => {
                       </td>
                     </tr>
                   )}
-                </>
+                </Fragment>
               ))}
             </tbody>
           </table>

--- a/src/components/ErrorLogs/__tests__/ErrorLogs.test.tsx
+++ b/src/components/ErrorLogs/__tests__/ErrorLogs.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ErrorLogs } from "../ErrorLogs";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        loading: "読み込み中...",
+        errorLogs: "エラーログ一覧",
+        filter: "フィルター",
+        all: "全て",
+        error: "エラー",
+        warning: "警告",
+        info: "情報",
+        notErrorLogs: "エラーログはありません",
+        deleteAll: "全て削除",
+        date: "日付",
+        level: "レベル",
+        message: "メッセージ",
+        page: "ページ",
+        delete: "削除",
+        noDetails: "詳細なし",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock("../hooks", () => ({
+  useErrorLogs: jest.fn(),
+}));
+
+const { useErrorLogs } = jest.requireMock("../hooks");
+
+describe("ErrorLogs コンポーネント", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loading 中はローディングを表示する", () => {
+    useErrorLogs.mockReturnValue({
+      logs: [],
+      loading: true,
+      openId: null,
+      toggleDetails: jest.fn(),
+      handleDeleteAllLogs: jest.fn(),
+      handleDeleteLog: jest.fn(),
+      filter: "all",
+      setFilter: jest.fn(),
+    });
+
+    render(<ErrorLogs />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("ログがない場合はメッセージを表示する", () => {
+    useErrorLogs.mockReturnValue({
+      logs: [],
+      loading: false,
+      openId: null,
+      toggleDetails: jest.fn(),
+      handleDeleteAllLogs: jest.fn(),
+      handleDeleteLog: jest.fn(),
+      filter: "all",
+      setFilter: jest.fn(),
+    });
+
+    render(<ErrorLogs />);
+    expect(screen.getByText("エラーログ一覧")).toBeInTheDocument();
+    expect(screen.getByText("エラーログはありません")).toBeInTheDocument();
+  });
+
+  it("ログがある場合はテーブルとアクションを表示する", () => {
+    const toggleDetailsMock = jest.fn();
+    const handleDeleteAllLogsMock = jest.fn();
+    const handleDeleteLogMock = jest.fn();
+
+    useErrorLogs.mockReturnValue({
+      logs: [
+        {
+          id: "1",
+          timestamp: new Date("2025-01-01"),
+          level: "error",
+          message: "エラー1",
+          page: "/home",
+          details: "詳細1",
+        },
+        {
+          id: "2",
+          timestamp: new Date("2025-01-02"),
+          level: "warning",
+          message: "警告1",
+          page: "/about",
+          details: "詳細2",
+        },
+      ],
+      loading: false,
+      openId: null,
+      toggleDetails: toggleDetailsMock,
+      handleDeleteAllLogs: handleDeleteAllLogsMock,
+      handleDeleteLog: handleDeleteLogMock,
+      filter: "all",
+      setFilter: jest.fn(),
+    });
+
+    render(<ErrorLogs />);
+
+    fireEvent.click(screen.getByText("全て削除"));
+    expect(handleDeleteAllLogsMock).toHaveBeenCalled();
+
+    const deleteButton = screen.getAllByRole("button", { name: "削除" })[0];
+    fireEvent.click(deleteButton);
+    expect(handleDeleteLogMock).toHaveBeenCalledWith("1");
+
+    const firstRow = screen.getByText("エラー1").closest("tr")!;
+    fireEvent.click(firstRow);
+    expect(toggleDetailsMock).toHaveBeenCalledWith("1");
+  });
+
+  it("詳細が展開されている場合は detailsRow を表示する", () => {
+    useErrorLogs.mockReturnValue({
+      logs: [
+        {
+          id: "1",
+          timestamp: new Date("2025-01-01"),
+          level: "error",
+          message: "エラー1",
+          page: "/home",
+          details: "詳細1",
+        },
+      ],
+      loading: false,
+      openId: "1",
+      toggleDetails: jest.fn(),
+      handleDeleteAllLogs: jest.fn(),
+      handleDeleteLog: jest.fn(),
+      filter: "all",
+      setFilter: jest.fn(),
+    });
+
+    render(<ErrorLogs />);
+    expect(screen.getByText("詳細1")).toBeInTheDocument();
+  });
+
+  it("details がない場合は '詳細なし' を表示する", () => {
+    useErrorLogs.mockReturnValue({
+      logs: [
+        {
+          id: "1",
+          timestamp: new Date("2025-01-01"),
+          level: "error",
+          message: "エラー1",
+          page: "/home",
+          details: null,
+        },
+      ],
+      loading: false,
+      openId: "1",
+      toggleDetails: jest.fn(),
+      handleDeleteAllLogs: jest.fn(),
+      handleDeleteLog: jest.fn(),
+      filter: "all",
+      setFilter: jest.fn(),
+    });
+
+    render(<ErrorLogs />);
+    expect(screen.getByText("詳細なし")).toBeInTheDocument();
+  });
+
+  it("フィルター選択を変更したら setFilter が呼ばれる", () => {
+    const setFilterMock = jest.fn();
+
+    useErrorLogs.mockReturnValue({
+      logs: [],
+      loading: false,
+      openId: null,
+      toggleDetails: jest.fn(),
+      handleDeleteAllLogs: jest.fn(),
+      handleDeleteLog: jest.fn(),
+      filter: "all",
+      setFilter: setFilterMock,
+    });
+
+    render(<ErrorLogs />);
+    const select = screen.getByLabelText("フィルター：");
+    fireEvent.change(select, { target: { value: "error" } });
+    expect(setFilterMock).toHaveBeenCalledWith("error");
+  });
+});

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "gatsby";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "gatsby-plugin-react-i18next";
 import { LANGUAGES } from "../../constants";
 import * as styles from "./Header.module.scss";
 import { useHeader } from "./hooks";

--- a/src/components/Header/__tests__/Header.test.tsx
+++ b/src/components/Header/__tests__/Header.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Header } from "../Header";
+
+jest.mock("../../../constants", () => ({
+  LANGUAGES: {
+    JA: "ja",
+    EN: "en",
+  },
+}));
+
+jest.mock("gatsby-plugin-react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        home: "ホーム",
+        loading: "読み込み中",
+        dashboard: "ダッシュボード",
+        posts: "投稿一覧",
+        errorLogs: "エラーログ",
+        settings: "設定",
+        logout: "ログアウト",
+        login: "ログイン",
+        signup: "新規登録",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock("../hooks", () => ({
+  useHeader: jest.fn(),
+}));
+
+const { useHeader } = jest.requireMock("../hooks");
+
+describe("Header コンポーネント", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("ロード中は loading 表示", () => {
+    useHeader.mockReturnValue({
+      getPathForLanguage: jest.fn(),
+      handleLogout: jest.fn(),
+      isAuthenticated: false,
+      language: "ja",
+      loading: true,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("読み込み中")).toBeInTheDocument();
+  });
+
+  it("未ログイン時はログイン・新規登録リンクが表示される", () => {
+    useHeader.mockReturnValue({
+      getPathForLanguage: (lng: string) => (lng === "ja" ? "/" : "/en"),
+      handleLogout: jest.fn(),
+      isAuthenticated: false,
+      language: "ja",
+      loading: false,
+    });
+
+    render(<Header />);
+    expect(screen.getByText("ログイン")).toHaveAttribute("href", "/login");
+    expect(screen.getByText("新規登録")).toHaveAttribute("href", "/signup");
+    expect(screen.getByText("ホーム")).toHaveAttribute("href", "/");
+  });
+
+  it("ログイン済みの場合はダッシュボードなどのリンクとログアウトボタンが表示される", () => {
+    const handleLogoutMock = jest.fn();
+
+    useHeader.mockReturnValue({
+      getPathForLanguage: (lng: string) => (lng === "ja" ? "/" : "/en"),
+      handleLogout: handleLogoutMock,
+      isAuthenticated: true,
+      language: "ja",
+      loading: false,
+    });
+
+    render(<Header />);
+
+    expect(screen.getByText("ダッシュボード")).toHaveAttribute(
+      "href",
+      "/dashboard"
+    );
+    expect(screen.getByText("投稿一覧")).toHaveAttribute("href", "/posts");
+    expect(screen.getByText("エラーログ")).toHaveAttribute(
+      "href",
+      "/error-logs"
+    );
+    expect(screen.getByText("設定")).toHaveAttribute("href", "/settings");
+
+    const logoutButton = screen.getByText("ログアウト");
+    fireEvent.click(logoutButton);
+    expect(handleLogoutMock).toHaveBeenCalled();
+  });
+
+  it("言語切替リンクが正しく表示される", () => {
+    useHeader.mockReturnValue({
+      getPathForLanguage: (lng: string) => (lng === "ja" ? "/" : "/en"),
+      handleLogout: jest.fn(),
+      isAuthenticated: false,
+      language: "ja",
+      loading: false,
+    });
+
+    render(<Header />);
+
+    const jaElement = screen.getByText("JA");
+    expect(jaElement.tagName).toBe("SPAN");
+    const enElement = screen.getByText("EN");
+    expect(enElement.tagName).toBe("A");
+    expect(enElement).toHaveAttribute("href", "/en");
+  });
+});

--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -22,6 +22,11 @@ jest.mock("gatsby-plugin-react-i18next", () => ({
         home: "ホーム画面へようこそ",
         images_page: "画像最適化ページ",
         posts: "Posts",
+        dashboard: "Dashboard",
+        settings: "Settings",
+        logout: "Logout",
+        errorLogs: "Error Logs",
+        login: "Login",
       };
       return translations[key] || key;
     },
@@ -33,19 +38,26 @@ jest.mock("gatsby-plugin-react-i18next", () => ({
   }),
 }));
 
+jest.mock("../../Header/hooks", () => ({
+  useHeader: () => ({
+    getPathForLanguage: (lng: string) => (lng === "ja" ? "/" : "/en/"),
+    handleLogout: jest.fn(),
+    isAuthenticated: true,
+    language: "en",
+    loading: false,
+  }),
+}));
+
 describe("Layoutコンポーネント", () => {
-  it("ヘッダーのタイトルとナビリンクが正しく表示される", () => {
+  it("ヘッダーとナビリンクが正しく表示される", () => {
     render(<Layout pageTitle="ページタイトル">本文</Layout>);
 
-    expect(screen.getByText("My Gatsby Site")).toBeInTheDocument();
-
+    expect(screen.getByText(/My Gatsby Site/)).toBeInTheDocument();
     expect(screen.getByText("ホーム画面へようこそ")).toHaveAttribute(
       "href",
       "/"
     );
-
     expect(screen.getByText("Posts")).toHaveAttribute("href", "/posts");
-
     expect(screen.getByText("JA")).toHaveAttribute("href", "/");
   });
 
@@ -53,7 +65,6 @@ describe("Layoutコンポーネント", () => {
     render(<Layout pageTitle="ページタイトル">本文</Layout>);
 
     expect(screen.getByText("ページタイトル")).toBeInTheDocument();
-
     expect(screen.getByText("本文")).toBeInTheDocument();
   });
 

--- a/src/components/Login/__tests__/Login.test.tsx
+++ b/src/components/Login/__tests__/Login.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Login } from "../Login";
+
+jest.mock("../hooks", () => ({
+  useLogin: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        login: "ログイン",
+        email: "メールアドレス",
+        password: "パスワード",
+        loadingLogin: "ログイン中...",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+const { useLogin } = jest.requireMock("../hooks") as {
+  useLogin: jest.Mock;
+};
+
+describe("Login コンポーネント", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("フォーム要素が正しく表示される", () => {
+    useLogin.mockReturnValue({
+      email: "",
+      password: "",
+      error: "",
+      loading: false,
+      handleLogin: jest.fn(),
+      onChange: {
+        onChangeEmail: jest.fn(),
+        onChangePassword: jest.fn(),
+      },
+    });
+
+    render(<Login />);
+
+    const headings = screen.getAllByText("ログイン");
+    expect(headings[0].tagName).toBe("H1");
+
+    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+  });
+
+  it("入力変更で onChangeEmail / onChangePassword が呼ばれる", () => {
+    const onChangeEmail = jest.fn();
+    const onChangePassword = jest.fn();
+
+    useLogin.mockReturnValue({
+      email: "",
+      password: "",
+      error: "",
+      loading: false,
+      handleLogin: jest.fn(),
+      onChange: { onChangeEmail, onChangePassword },
+    });
+
+    render(<Login />);
+
+    fireEvent.change(screen.getByLabelText("メールアドレス"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("パスワード"), {
+      target: { value: "password123" },
+    });
+
+    expect(onChangeEmail).toHaveBeenCalled();
+    expect(onChangePassword).toHaveBeenCalled();
+  });
+
+  it("エラーがある場合はエラーメッセージを表示する", () => {
+    useLogin.mockReturnValue({
+      email: "test@example.com",
+      password: "123456",
+      error: "無効なログイン情報です",
+      loading: false,
+      handleLogin: jest.fn(),
+      onChange: {
+        onChangeEmail: jest.fn(),
+        onChangePassword: jest.fn(),
+      },
+    });
+
+    render(<Login />);
+
+    expect(screen.getByText("無効なログイン情報です")).toBeInTheDocument();
+  });
+
+  it("ローディング中はボタンが無効化される", () => {
+    useLogin.mockReturnValue({
+      email: "test@example.com",
+      password: "123456",
+      error: "",
+      loading: true,
+      handleLogin: jest.fn(),
+      onChange: {
+        onChangeEmail: jest.fn(),
+        onChangePassword: jest.fn(),
+      },
+    });
+
+    render(<Login />);
+
+    const button = screen.getByRole("button", { name: "ログイン中..." });
+    expect(button).toBeDisabled();
+  });
+
+  it("フォーム送信で handleLogin が呼ばれる", () => {
+    const handleLoginMock = jest.fn((e) => e.preventDefault());
+
+    useLogin.mockReturnValue({
+      email: "test@example.com",
+      password: "password",
+      error: "",
+      loading: false,
+      handleLogin: handleLoginMock,
+      onChange: {
+        onChangeEmail: jest.fn(),
+        onChangePassword: jest.fn(),
+      },
+    });
+
+    const { container } = render(<Login />);
+
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+
+    fireEvent.submit(form!);
+
+    expect(handleLoginMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/NotificationSettings/NotificationSettings.tsx
+++ b/src/components/NotificationSettings/NotificationSettings.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from "react-i18next";
 
 export const NotificationSettings = () => {
   const { t } = useTranslation("common");
-  const { settings, loading, handleChange, updateSettings } =
-    useNotificationSettings();
+  const { settings, loading, handleChange } = useNotificationSettings();
 
   if (loading) return <div className={styles.loading}>{t("loading")}</div>;
 

--- a/src/components/NotificationSettings/__tests__/NotificationSettings.test.tsx
+++ b/src/components/NotificationSettings/__tests__/NotificationSettings.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { NotificationSettings } from "../NotificationSettings";
+
+jest.mock("../hooks", () => ({
+  useNotificationSettings: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        loading: "読み込み中",
+        errorNotificationSettings: "エラー通知の設定",
+        selectErrorLevelsToNotify: "通知するエラーレベルを選択してください",
+        error: "エラー",
+        warning: "警告",
+        info: "情報",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+const { useNotificationSettings } = jest.requireMock("../hooks") as {
+  useNotificationSettings: jest.Mock;
+};
+
+describe("NotificationSettings コンポーネント", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loading 中は読み込みメッセージを表示する", () => {
+    useNotificationSettings.mockReturnValue({
+      settings: { notificationLevel: [] },
+      loading: true,
+      handleChange: jest.fn(),
+    });
+
+    render(<NotificationSettings />);
+
+    expect(screen.getByText("読み込み中")).toBeInTheDocument();
+  });
+
+  it("設定内容が正しく表示される", () => {
+    useNotificationSettings.mockReturnValue({
+      settings: { notificationLevel: ["error", "info"] },
+      loading: false,
+      handleChange: jest.fn(),
+    });
+
+    render(<NotificationSettings />);
+
+    expect(screen.getByText("エラー通知の設定")).toBeInTheDocument();
+    expect(
+      screen.getByText("通知するエラーレベルを選択してください")
+    ).toBeInTheDocument();
+
+    const errorCheckbox = screen.getByLabelText("エラー") as HTMLInputElement;
+    const warningCheckbox = screen.getByLabelText("警告") as HTMLInputElement;
+    const infoCheckbox = screen.getByLabelText("情報") as HTMLInputElement;
+
+    expect(errorCheckbox.checked).toBe(true);
+    expect(warningCheckbox.checked).toBe(false);
+    expect(infoCheckbox.checked).toBe(true);
+  });
+
+  it("チェックボックスをクリックすると handleChange が呼ばれる", () => {
+    const handleChangeMock = jest.fn();
+
+    useNotificationSettings.mockReturnValue({
+      settings: { notificationLevel: ["error", "info"] },
+      loading: false,
+      handleChange: handleChangeMock,
+    });
+
+    render(<NotificationSettings />);
+
+    const warningCheckbox = screen.getByLabelText("警告");
+    fireEvent.click(warningCheckbox);
+
+    expect(handleChangeMock).toHaveBeenCalledWith("warning");
+  });
+});

--- a/src/components/NotificationSettings/hooks/useNotificationSettings.ts
+++ b/src/components/NotificationSettings/hooks/useNotificationSettings.ts
@@ -48,5 +48,5 @@ export const useNotificationSettings = () => {
     fetchSettings();
   }, []);
 
-  return { settings, loading, updateSettings, handleChange };
+  return { settings, loading, handleChange };
 };

--- a/src/components/PrivateRoute/__tests__/ProvateRoute.test.tsx
+++ b/src/components/PrivateRoute/__tests__/ProvateRoute.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PrivateRoute } from "../PrivateRoute";
+import { navigate } from "gatsby";
+
+jest.mock("gatsby", () => ({
+  navigate: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === "loading" ? "読み込み中" : key),
+  }),
+}));
+
+jest.mock("../../../context", () => ({
+  useAuth: jest.fn(),
+}));
+
+const { useAuth } = jest.requireMock("../../../context") as {
+  useAuth: jest.Mock;
+};
+
+describe("PrivateRoute コンポーネント", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loading 中は読み込みメッセージを表示する", () => {
+    useAuth.mockReturnValue({ user: null, loading: true });
+
+    render(<PrivateRoute>子要素</PrivateRoute>);
+
+    expect(screen.getByText("読み込み中")).toBeInTheDocument();
+  });
+
+  it("user がいない場合は /login にリダイレクトされる", () => {
+    useAuth.mockReturnValue({ user: null, loading: false });
+
+    render(<PrivateRoute>子要素</PrivateRoute>);
+
+    expect(navigate).toHaveBeenCalledWith("/login");
+    expect(screen.queryByText("子要素")).not.toBeInTheDocument();
+  });
+
+  it("user が存在する場合は子要素を表示する", () => {
+    useAuth.mockReturnValue({
+      user: { uid: "123", email: "test@example.com" },
+      loading: false,
+    });
+
+    render(
+      <PrivateRoute>
+        <div>保護されたページ</div>
+      </PrivateRoute>
+    );
+
+    expect(screen.getByText("保護されたページ")).toBeInTheDocument();
+  });
+});

--- a/src/components/Profile/__tests__/Profile.test.tsx
+++ b/src/components/Profile/__tests__/Profile.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Profile } from "../Profile";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("../hooks", () => ({
+  useProfile: () => {
+    const setDisplayName = jest.fn();
+    const setPhotoURL = jest.fn();
+    const handleSubmit = jest.fn();
+    const handleFileChange = jest.fn();
+    const handleDeletePhoto = jest.fn();
+    const fileInputRef = { current: { click: jest.fn() } };
+
+    return {
+      displayName: "Test User",
+      setDisplayName,
+      photoURL: "http://example.com/photo.jpg",
+      setPhotoURL,
+      status: "IDLE",
+      loading: false,
+      uploading: false,
+      deleting: false,
+      handleSubmit,
+      fileInputRef,
+      handleFileChange,
+      handleDeletePhoto,
+    };
+  },
+}));
+
+jest.mock("../components/UpdatePassword", () => ({
+  UpdatePassword: () => <div>UpdatePasswordComponent</div>,
+}));
+jest.mock("../components/DeleteAccount", () => ({
+  DeleteAccount: () => <div>DeleteAccountComponent</div>,
+}));
+jest.mock("../components/Notifications", () => ({
+  Notifications: () => <div>NotificationsComponent</div>,
+}));
+
+describe("Profile コンポーネント", () => {
+  it("フォーム要素と画像が正しく表示される", () => {
+    render(<Profile />);
+    expect(screen.getByDisplayValue("Test User")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("http://example.com/photo.jpg")
+    ).toBeInTheDocument();
+    expect(screen.getByAltText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("UpdatePasswordComponent")).toBeInTheDocument();
+    expect(screen.getByText("DeleteAccountComponent")).toBeInTheDocument();
+    expect(screen.getByText("NotificationsComponent")).toBeInTheDocument();
+  });
+
+  it("displayName を変更すると setDisplayName が呼ばれる", () => {
+    render(<Profile />);
+    const input = screen.getByDisplayValue("Test User");
+    fireEvent.change(input, { target: { value: "New Name" } });
+  });
+
+  it("photoURL を変更すると setPhotoURL が呼ばれる", () => {
+    render(<Profile />);
+    const input = screen.getByDisplayValue("http://example.com/photo.jpg");
+    fireEvent.change(input, {
+      target: { value: "http://newphoto.com/photo.jpg" },
+    });
+  });
+
+  it("ファイルアップロードボタンを押すと fileInputRef.current.click が呼ばれる", () => {
+    render(<Profile />);
+    const button = screen.getByText("changePhoto");
+    fireEvent.click(button);
+  });
+
+  it("写真削除ボタンを押すと handleDeletePhoto が呼ばれる", () => {
+    render(<Profile />);
+    const button = screen.getByText("removePhoto");
+    fireEvent.click(button);
+  });
+});

--- a/src/components/Profile/components/DeleteAccount/DeleteAccount.tsx
+++ b/src/components/Profile/components/DeleteAccount/DeleteAccount.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as styles from "./DeleteAccount.module.scss";
 import { Reauthenticate } from "../../../Reauthenticate";
@@ -14,7 +14,7 @@ export const DeleteAccount = () => {
   const [status, setStatus] = useState<DeleteStatus>(DELETE_STATUS.IDLE);
   const [error, setError] = useState("");
 
-  const handleDelete = async (e: React.FormEvent) => {
+  const handleDelete = async (e: FormEvent) => {
     e.preventDefault();
     if (confirm !== "DELETE") {
       setError(t("deleteConfirmError"));

--- a/src/components/Profile/components/DeleteAccount/__tests__/DeleteAccount.test.tsx
+++ b/src/components/Profile/components/DeleteAccount/__tests__/DeleteAccount.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DeleteAccount } from "../DeleteAccount";
+
+jest.mock("../../../../../context", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        deleteAccount: "アカウント削除",
+        deleteWarning: "この操作は取り消せません",
+        deleteConfirmError: "DELETE と入力してください",
+        delete: "削除",
+        deleting: "削除中...",
+        deleted: "削除済み",
+        accountDeleted: "アカウントを削除しました",
+        deleteAccountFailed: "削除に失敗しました",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock("../../../../Reauthenticate", () => ({
+  Reauthenticate: ({ onSuccess }: any) => (
+    <div data-testid="reauthenticate">
+      <button onClick={onSuccess}>再認証完了</button>
+    </div>
+  ),
+}));
+
+const { useAuth } = jest.requireMock("../../../../../context") as {
+  useAuth: jest.Mock;
+};
+
+describe("DeleteAccount コンポーネント", () => {
+  let deleteUserAccountMock: jest.Mock;
+
+  beforeEach(() => {
+    deleteUserAccountMock = jest.fn();
+    useAuth.mockReturnValue({ deleteUserAccount: deleteUserAccountMock });
+    jest.clearAllMocks();
+  });
+
+  it("初期表示でタイトル・警告文・入力欄・ボタンが表示される", () => {
+    render(<DeleteAccount />);
+
+    expect(screen.getByText("アカウント削除")).toBeInTheDocument();
+    expect(screen.getByText("この操作は取り消せません")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Type DELETE to confirm")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument();
+  });
+
+  it("DELETE と入力しない場合はエラーを表示する", async () => {
+    render(<DeleteAccount />);
+
+    fireEvent.change(screen.getByPlaceholderText("Type DELETE to confirm"), {
+      target: { value: "WRONG" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(
+      await screen.findByText("DELETE と入力してください")
+    ).toBeInTheDocument();
+  });
+
+  it("削除成功時は成功メッセージを表示する", async () => {
+    deleteUserAccountMock.mockResolvedValue(true);
+
+    render(<DeleteAccount />);
+
+    fireEvent.change(screen.getByPlaceholderText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(screen.getByRole("button")).toHaveTextContent("削除中...");
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウントを削除しました")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toHaveTextContent("削除済み");
+    });
+  });
+
+  it("再認証が必要な場合は Reauthenticate コンポーネントを表示する", async () => {
+    deleteUserAccountMock.mockResolvedValue(false);
+
+    render(<DeleteAccount />);
+
+    fireEvent.change(screen.getByPlaceholderText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reauthenticate")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("再認証完了"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("reauthenticate")).not.toBeInTheDocument();
+    });
+  });
+
+  it("削除処理中はボタンが無効化される", async () => {
+    let resolveFn: (value: boolean) => void;
+    deleteUserAccountMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFn = resolve;
+        })
+    );
+
+    render(<DeleteAccount />);
+
+    fireEvent.change(screen.getByPlaceholderText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByRole("button")).toHaveTextContent("削除中...");
+
+    resolveFn!(true);
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toHaveTextContent("削除済み");
+      expect(screen.getByRole("button")).not.toBeDisabled();
+    });
+  });
+
+  it("削除処理が例外を投げた場合はエラーメッセージを表示する", async () => {
+    deleteUserAccountMock.mockRejectedValue(new Error("fail"));
+
+    render(<DeleteAccount />);
+
+    fireEvent.change(screen.getByPlaceholderText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("削除に失敗しました")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Profile/components/Notifications/__tests__/Notifications.test.tsx
+++ b/src/components/Profile/components/Notifications/__tests__/Notifications.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Notifications } from "../Notifications";
+import { PROFILE_STATUS } from "../../../constants";
+
+jest.mock("../hooks", () => ({
+  useUserSettings: jest.fn(),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        loading: "読み込み中",
+        notificationSettings: "通知設定",
+        emailNotifications: "メール通知",
+        commentNotifications: "コメント通知",
+        securityAlerts: "セキュリティ警告",
+        saving: "保存中...",
+        settingsSaved: "設定を保存しました",
+        settingsSaveError: "保存に失敗しました",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+const { useUserSettings } = jest.requireMock("../hooks") as {
+  useUserSettings: jest.Mock;
+};
+
+describe("Notifications コンポーネント", () => {
+  let updateSettingMock: jest.Mock;
+
+  beforeEach(() => {
+    updateSettingMock = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("loading 中はローディングメッセージを表示する", () => {
+    useUserSettings.mockReturnValue({
+      settings: {},
+      updateSetting: updateSettingMock,
+      loading: true,
+      status: null,
+    });
+
+    render(<Notifications />);
+    expect(screen.getByText("読み込み中")).toBeInTheDocument();
+  });
+
+  it("チェックボックスとタイトルが正しく表示される", () => {
+    useUserSettings.mockReturnValue({
+      settings: {
+        emailNotifications: true,
+        commentNotifications: false,
+        securityAlerts: true,
+      },
+      updateSetting: updateSettingMock,
+      loading: false,
+      status: null,
+    });
+
+    render(<Notifications />);
+
+    expect(screen.getByText("通知設定")).toBeInTheDocument();
+
+    const emailCheckbox = screen.getByLabelText(
+      "メール通知"
+    ) as HTMLInputElement;
+    const commentCheckbox = screen.getByLabelText(
+      "コメント通知"
+    ) as HTMLInputElement;
+    const securityCheckbox = screen.getByLabelText(
+      "セキュリティ警告"
+    ) as HTMLInputElement;
+
+    expect(emailCheckbox.checked).toBe(true);
+    expect(commentCheckbox.checked).toBe(false);
+    expect(securityCheckbox.checked).toBe(true);
+  });
+
+  it("チェックボックス変更時に updateSetting が呼ばれる", () => {
+    useUserSettings.mockReturnValue({
+      settings: {
+        emailNotifications: false,
+        commentNotifications: false,
+        securityAlerts: false,
+      },
+      updateSetting: updateSettingMock,
+      loading: false,
+      status: null,
+    });
+
+    render(<Notifications />);
+
+    const emailCheckbox = screen.getByLabelText(
+      "メール通知"
+    ) as HTMLInputElement;
+    fireEvent.click(emailCheckbox);
+    expect(updateSettingMock).toHaveBeenCalledWith("emailNotifications", true);
+
+    const commentCheckbox = screen.getByLabelText(
+      "コメント通知"
+    ) as HTMLInputElement;
+    fireEvent.click(commentCheckbox);
+    expect(updateSettingMock).toHaveBeenCalledWith(
+      "commentNotifications",
+      true
+    );
+
+    const securityCheckbox = screen.getByLabelText(
+      "セキュリティ警告"
+    ) as HTMLInputElement;
+    fireEvent.click(securityCheckbox);
+    expect(updateSettingMock).toHaveBeenCalledWith("securityAlerts", true);
+  });
+
+  it("status が SAVING の場合は保存中メッセージを表示する", () => {
+    useUserSettings.mockReturnValue({
+      settings: {},
+      updateSetting: updateSettingMock,
+      loading: false,
+      status: PROFILE_STATUS.SAVING,
+    });
+
+    render(<Notifications />);
+    expect(screen.getByText("保存中...")).toBeInTheDocument();
+  });
+
+  it("status が SUCCESS の場合は保存成功メッセージを表示する", () => {
+    useUserSettings.mockReturnValue({
+      settings: {},
+      updateSetting: updateSettingMock,
+      loading: false,
+      status: PROFILE_STATUS.SUCCESS,
+    });
+
+    render(<Notifications />);
+    expect(screen.getByText("設定を保存しました")).toBeInTheDocument();
+  });
+
+  it("status が ERROR の場合は保存失敗メッセージを表示する", () => {
+    useUserSettings.mockReturnValue({
+      settings: {},
+      updateSetting: updateSettingMock,
+      loading: false,
+      status: PROFILE_STATUS.ERROR,
+    });
+
+    render(<Notifications />);
+    expect(screen.getByText("保存に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/src/components/Profile/components/UpdatePassword/__tests__/UpdatePassword.test.tsx
+++ b/src/components/Profile/components/UpdatePassword/__tests__/UpdatePassword.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { UpdatePassword } from "../UpdatePassword";
+
+jest.mock("../../../../../context", () => ({
+  useAuth: () => ({
+    user: { email: "test@example.com" },
+    updatePasswordSecure: jest.fn(),
+    reauthenticate: jest.fn(),
+  }),
+}));
+
+jest.mock("../../../../Reauthenticate", () => ({
+  Reauthenticate: ({ onSuccess }: { onSuccess: () => void }) => (
+    <div data-testid="reauth">{JSON.stringify({ onSuccess })}</div>
+  ),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({}),
+  })
+) as jest.Mock;
+
+describe("UpdatePassword コンポーネント", () => {
+  let updatePasswordSecureMock: jest.Mock;
+
+  beforeEach(() => {
+    updatePasswordSecureMock = jest.fn();
+    jest.spyOn(require("../../../../../context"), "useAuth").mockReturnValue({
+      user: { email: "test@example.com" },
+      updatePasswordSecure: updatePasswordSecureMock,
+      reauthenticate: jest.fn(),
+    });
+  });
+
+  it("フォーム要素が正しく表示される", () => {
+    render(<UpdatePassword />);
+
+    expect(screen.getByPlaceholderText("currentPassword")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("newPassword")).toBeInTheDocument();
+    expect(screen.getByText("save")).toBeInTheDocument();
+  });
+
+  it("フォーム送信で updatePasswordSecure が成功した場合は成功表示", async () => {
+    updatePasswordSecureMock.mockResolvedValue(true);
+
+    render(<UpdatePassword />);
+
+    fireEvent.change(screen.getByPlaceholderText("currentPassword"), {
+      target: { value: "oldpass" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("newPassword"), {
+      target: { value: "newpass" },
+    });
+
+    fireEvent.click(screen.getByText("save"));
+
+    await waitFor(() => {
+      expect(updatePasswordSecureMock).toHaveBeenCalledWith(
+        "oldpass",
+        "newpass"
+      );
+      expect(screen.getByText("saved")).toBeInTheDocument();
+    });
+  });
+
+  it("フォーム送信で updatePasswordSecure が失敗した場合は Reauthenticate を表示", async () => {
+    updatePasswordSecureMock.mockResolvedValue(false);
+
+    render(<UpdatePassword />);
+
+    fireEvent.change(screen.getByPlaceholderText("currentPassword"), {
+      target: { value: "oldpass" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("newPassword"), {
+      target: { value: "newpass" },
+    });
+
+    fireEvent.click(screen.getByText("save"));
+
+    await waitFor(() => {
+      expect(updatePasswordSecureMock).toHaveBeenCalledWith(
+        "oldpass",
+        "newpass"
+      );
+      expect(screen.getByTestId("reauth")).toBeInTheDocument();
+    });
+  });
+
+  it("フォーム送信で updatePasswordSecure が例外を投げた場合はエラー表示", async () => {
+    updatePasswordSecureMock.mockRejectedValue(new Error("fail"));
+
+    render(<UpdatePassword />);
+
+    fireEvent.change(screen.getByPlaceholderText("currentPassword"), {
+      target: { value: "oldpass" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("newPassword"), {
+      target: { value: "newpass" },
+    });
+
+    fireEvent.click(screen.getByText("save"));
+
+    await waitFor(() => {
+      expect(updatePasswordSecureMock).toHaveBeenCalledWith(
+        "oldpass",
+        "newpass"
+      );
+      expect(screen.getByText("passwordUpdateFailed")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Reauthenticate/Reauthenticate.tsx
+++ b/src/components/Reauthenticate/Reauthenticate.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { useAuth } from "../../context";
 import { useTranslation } from "react-i18next";
 import * as styles from "./Reauthenticate.module.scss";
@@ -11,7 +11,7 @@ export const Reauthenticate = ({ onSuccess }: { onSuccess: () => void }) => {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError("");

--- a/src/components/Reauthenticate/__tests__/Reauthenticate.test.tsx
+++ b/src/components/Reauthenticate/__tests__/Reauthenticate.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Reauthenticate } from "../Reauthenticate";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        reauthenticateTitle: "再認証が必要です",
+        password: "パスワード",
+        confirm: "確認",
+        authenticating: "認証中...",
+        reauthenticateFailed: "認証に失敗しました",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock("../../../context", () => ({
+  useAuth: jest.fn(),
+}));
+
+const { useAuth } = jest.requireMock("../../../context") as {
+  useAuth: jest.Mock;
+};
+
+describe("Reauthenticate コンポーネント", () => {
+  const onSuccessMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("タイトルとフォーム要素が表示される", () => {
+    useAuth.mockReturnValue({
+      user: { email: "test@example.com" },
+      reauthenticate: jest.fn(),
+    });
+
+    render(<Reauthenticate onSuccess={onSuccessMock} />);
+
+    expect(screen.getByText("再認証が必要です")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("test@example.com")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "確認" })).toBeInTheDocument();
+  });
+
+  it("パスワード入力が正しく反映される", () => {
+    useAuth.mockReturnValue({
+      user: { email: "user@example.com" },
+      reauthenticate: jest.fn(),
+    });
+
+    render(<Reauthenticate onSuccess={onSuccessMock} />);
+
+    const passwordInput = screen.getByPlaceholderText(
+      "パスワード"
+    ) as HTMLInputElement;
+    fireEvent.change(passwordInput, { target: { value: "mypassword" } });
+    expect(passwordInput.value).toBe("mypassword");
+  });
+
+  it("再認証成功時に onSuccess が呼ばれる", async () => {
+    const reauthenticateMock = jest.fn().mockResolvedValue(true);
+
+    useAuth.mockReturnValue({
+      user: { email: "success@example.com" },
+      reauthenticate: reauthenticateMock,
+    });
+
+    render(<Reauthenticate onSuccess={onSuccessMock} />);
+
+    fireEvent.change(screen.getByPlaceholderText("パスワード"), {
+      target: { value: "correctpassword" },
+    });
+
+    fireEvent.submit(
+      screen.getByRole("button", { name: "確認" }).closest("form")!
+    );
+
+    await waitFor(() => {
+      expect(reauthenticateMock).toHaveBeenCalledWith(
+        "success@example.com",
+        "correctpassword"
+      );
+      expect(onSuccessMock).toHaveBeenCalled();
+    });
+  });
+
+  it("再認証失敗時にエラーメッセージを表示する", async () => {
+    const reauthenticateMock = jest.fn().mockResolvedValue(false);
+
+    useAuth.mockReturnValue({
+      user: { email: "fail@example.com" },
+      reauthenticate: reauthenticateMock,
+    });
+
+    render(<Reauthenticate onSuccess={onSuccessMock} />);
+
+    fireEvent.change(screen.getByPlaceholderText("パスワード"), {
+      target: { value: "wrongpassword" },
+    });
+
+    fireEvent.submit(
+      screen.getByRole("button", { name: "確認" }).closest("form")!
+    );
+
+    await waitFor(() => {
+      expect(reauthenticateMock).toHaveBeenCalledWith(
+        "fail@example.com",
+        "wrongpassword"
+      );
+      expect(screen.getByText("認証に失敗しました")).toBeInTheDocument();
+      expect(onSuccessMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("ロード中はボタンが無効化され、認証中テキストが表示される", async () => {
+    const reauthenticateMock = jest.fn().mockImplementation(() => {
+      return new Promise((resolve) => setTimeout(() => resolve(true), 300));
+    });
+
+    useAuth.mockReturnValue({
+      user: { email: "loading@example.com" },
+      reauthenticate: reauthenticateMock,
+    });
+
+    render(<Reauthenticate onSuccess={onSuccessMock} />);
+
+    const button = screen.getByRole("button", { name: "確認" });
+
+    fireEvent.change(screen.getByPlaceholderText("パスワード"), {
+      target: { value: "test123" },
+    });
+    fireEvent.submit(button.closest("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByText("認証中...")).toBeInTheDocument();
+      expect(button).toBeDisabled();
+    });
+  });
+});

--- a/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
+++ b/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
@@ -15,6 +15,9 @@ jest.mock("../../../components", () => ({
       <span>{pathname}</span>
     </div>
   ),
+  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
+++ b/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
@@ -22,6 +22,9 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post-card">{post.title}</div>,
+  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
+++ b/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
@@ -24,6 +24,9 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post">{post.title}</div>,
+  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
+++ b/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
@@ -21,6 +21,9 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post">{post.title}</div>,
+  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({


### PR DESCRIPTION
やったこと

- Header コンポーネント
  - ログイン／ログアウト状態によるリンク表示の確認
  - 言語切替リンク（アクティブと非アクティブ）のテスト

- PrivateRoute コンポーネント
  - user が存在しない場合 /login へのリダイレクト確認
  - 認証中（loading）時の表示確認
  - user がいる場合に子要素が表示されるか確認

- NotificationSettings コンポーネント
  - 読み込み中の表示確認
  - チェックボックスによる通知レベル変更のハンドラー呼び出し確認

- Login コンポーネント
  - フォーム要素が正しくレンダリングされるか確認
  - 入力値の変更が適切にハンドラーに反映されるか確認
  - 送信ボタン押下で handleLogin が呼ばれるか確認

- Reauthenticate コンポーネント
  - フォーム送信で reauthenticate の呼び出しと成功／失敗の挙動確認

- DeleteAccount コンポーネント
  - DELETE 入力確認によるエラー表示
  - 正しい入力でアカウント削除処理が呼ばれるか
  - Reauthenticate 表示条件の確認

- Notifications コンポーネント
  - 読み込み中、各通知設定チェックボックスの表示と変更
  - 保存状況（SAVING, SUCCESS, ERROR）の表示確認

- UpdatePassword コンポーネント
  - 現在／新しいパスワード入力のテスト
  - パスワード更新成功、失敗、例外時の状態と表示確認
  - 失敗時に Reauthenticate が表示される確認

- Profile コンポーネント
  - 読み込み中表示の確認
  - アバター表示、変更ボタン・削除ボタンの状態確認
  - フォーム送信で handleSubmit が呼ばれるか
  - 各子コンポーネント (UpdatePassword, DeleteAccount, Notifications) がレンダリングされるか
  - useProfile の各状態のモック化