### PR TITLE
[24日目]：各ページのレスポンシブ対応

### DIFF
--- a/__mocks__/gatsby.ts
+++ b/__mocks__/gatsby.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement } from "react";
 
 export const graphql = jest.fn();
 export const StaticQuery = jest.fn();
@@ -8,5 +8,5 @@ export const Link = jest
   .fn()
   .mockImplementation(
     ({ to, ...rest }: { to: string; [key: string]: unknown }) =>
-      React.createElement("a", { href: to, ...rest })
+      createElement("a", { href: to, ...rest })
   );

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,6 +1,6 @@
 import { logErrorToServer } from "./src/utils";
 import { AuthProvider } from "./src/context/AuthContext";
-import React from "react";
+import { ReactNode } from "react";
 
 declare global {
   interface Window {
@@ -25,7 +25,7 @@ export const onRouteUpdate = ({ location }: { location: Location }) => {
   }
 };
 
-export const wrapRootElement = ({ element }: { element: React.ReactNode }) => {
+export const wrapRootElement = ({ element }: { element: ReactNode }) => {
   return <AuthProvider>{element}</AuthProvider>;
 };
 

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { ReactNode } from "react";
 import { AuthProvider } from "./src/context/AuthContext";
 
-export const wrapRootElement = ({ element }: { element: React.ReactNode }) => {
+export const wrapRootElement = ({ element }: { element: ReactNode }) => {
   return <AuthProvider>{element}</AuthProvider>;
 };

--- a/src/components/Dashboard/Dashboard.module.scss
+++ b/src/components/Dashboard/Dashboard.module.scss
@@ -3,48 +3,77 @@
   justify-content: center;
   align-items: center;
   min-height: 80vh;
-  background: #f5f6fa;
+  background: #f5f7fa;
   padding: 2rem;
+  animation: fadeIn 0.4s ease-out;
+
+  @media (max-width: 768px) {
+    padding: 1.5rem 1rem;
+  }
 }
 
 .card {
   background: #ffffff;
-  padding: 2rem 3rem;
+  padding: 2.5rem 3rem;
   border-radius: 1rem;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-  max-width: 480px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.08);
+  max-width: 520px;
   width: 100%;
   text-align: left;
-  animation: fadeIn 0.4s ease-out;
+  animation: slideUp 0.4s ease-out;
+
+  @media (max-width: 768px) {
+    padding: 1.8rem 1.2rem;
+  }
 }
 
 .title {
-  font-size: 1.6rem;
-  margin-bottom: 1rem;
-  border-bottom: 2px solid #007acc;
-  padding-bottom: 0.3rem;
-  color: #333;
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 3px solid #007acc;
+  padding-bottom: 0.4rem;
+  color: #222;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-align: center;
+
+  @media (max-width: 480px) {
+    font-size: 1.5rem;
+  }
 }
 
 .infoList {
   list-style: none;
   padding: 0;
-  margin: 1.5rem 0 2rem;
+  margin: 1.5rem 0 2.5rem;
+  line-height: 1.6;
 
   li {
-    margin-bottom: 0.8rem;
+    margin-bottom: 1rem;
     font-size: 0.95rem;
     color: #444;
+    display: flex;
+    flex-wrap: wrap;
 
     strong {
-      display: inline-block;
-      width: 120px;
+      min-width: 120px;
+      font-weight: 600;
       color: #111;
+      margin-right: 0.5rem;
+    }
+
+    @media (max-width: 480px) {
+      flex-direction: column;
+      strong {
+        margin-bottom: 0.2rem;
+      }
     }
   }
 }
 
 .logoutButton {
+  display: block;
+  margin: 0 auto;
   background: #e63946;
   color: #fff;
   border: none;
@@ -52,10 +81,18 @@
   border-radius: 0.5rem;
   cursor: pointer;
   font-size: 1rem;
-  transition: background 0.3s ease;
+  font-weight: 500;
+  transition: all 0.3s ease;
 
   &:hover {
     background: #c62828;
+    transform: translateY(-2px);
+    box-shadow: 0 3px 10px rgba(230, 57, 70, 0.3);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: none;
   }
 }
 
@@ -64,6 +101,52 @@
   font-size: 1.1rem;
   padding: 3rem;
   color: #555;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.errorBox {
+  background: #fff5f5;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  color: #991b1b;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  margin: 2rem auto;
+  max-width: 600px;
+  animation: fadeIn 0.3s ease-in-out;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+
+  h1 {
+    font-size: 1.3rem;
+    margin-bottom: 0.8rem;
+  }
+
+  p {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+  }
+}
+
+.reloadButton {
+  background-color: #b91c1c;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    background-color: #a31616;
+    transform: translateY(-2px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
 }
 
 @keyframes fadeIn {
@@ -77,44 +160,10 @@
   }
 }
 
-.errorBox {
-  background: #fee2e2;
-  border: 1px solid #fecaca;
-  border-radius: 10px;
-  color: #991b1b;
-  padding: 1.5rem;
-  text-align: center;
-  margin: 2rem auto;
-  max-width: 600px;
-  animation: fadeIn 0.3s ease-in-out;
-}
-
-.reloadButton {
-  background-color: #991b1b;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  padding: 0.6rem 1.2rem;
-  font-weight: bold;
-  margin-top: 1rem;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-}
-
-.reloadButton:hover {
-  background-color: #b91c1c;
-}
-
-.loading {
-  text-align: center;
-  font-size: 1.2rem;
-  margin-top: 3rem;
-}
-
-@keyframes fadeIn {
+@keyframes slideUp {
   from {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: translateY(12px);
   }
   to {
     opacity: 1;

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -2,8 +2,9 @@ import { useTranslation } from "react-i18next";
 import { DashboardProps } from "./types";
 import { useAuth } from "../../context";
 import * as styles from "./Dashboard.module.scss";
+import { FC } from "react";
 
-export const Dashboard: React.FC<DashboardProps> = ({ reloadFn }) => {
+export const Dashboard: FC<DashboardProps> = ({ reloadFn }) => {
   const { t } = useTranslation("common");
   const { error, user, logout, loading } = useAuth();
 

--- a/src/components/ErrorLogs/ErrorLogs.module.scss
+++ b/src/components/ErrorLogs/ErrorLogs.module.scss
@@ -1,16 +1,96 @@
 .loading {
   text-align: center;
-  margin: 1rem;
-  font-size: 24px;
+  margin: 2rem 0;
+  font-size: 1.5rem;
+  color: #555;
 }
 
 .container {
   padding: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .title {
   font-size: 1.8rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  color: #111827;
+}
+
+.filterArea {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+
+  label {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  select {
+    padding: 0.5rem 0.8rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background-color: #fff;
+    color: #111827;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    appearance: none;
+
+    &:hover {
+      border-color: #9ca3af;
+    }
+
+    &:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+    }
+  }
+}
+
+.actions {
+  text-align: right;
+  margin-bottom: 12px;
+}
+
+.deleteButton,
+.deleteAllButton {
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.deleteButton {
+  background-color: #d9534f;
+  color: #fff;
+  padding: 4px 10px;
+  font-size: 0.9rem;
+
+  &:hover {
+    background-color: #c9302c;
+    transform: scale(1.05);
+  }
+}
+
+.deleteAllButton {
+  background-color: #a94442;
+  color: #fff;
+  padding: 6px 14px;
+
+  &:hover {
+    background-color: #843534;
+    transform: scale(1.05);
+  }
 }
 
 .table {
@@ -19,24 +99,34 @@
 
   th,
   td {
-    padding: 0.6rem;
+    padding: 0.6rem 0.8rem;
     border-bottom: 1px solid #ddd;
     text-align: left;
   }
 
   tr:hover {
     background-color: #f9f9f9;
-    cursor: pointer;
   }
 
   .detailsRow {
     background-color: #fafafa;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.35s ease, padding 0.35s ease;
+    padding: 0 0.8rem;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .detailsRow.open {
+    max-height: 500px;
+    padding: 0.6rem 0.8rem;
   }
 
   .details {
     white-space: pre-wrap;
     font-size: 0.9rem;
     color: #333;
+    margin: 0;
   }
 }
 
@@ -55,72 +145,71 @@
   color: #2e7d32;
 }
 
-.actions {
-  text-align: right;
-  margin-bottom: 12px;
-}
-
-.deleteButton {
-  background-color: #d9534f;
-  color: white;
-  border: none;
-  padding: 4px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.9rem;
-
-  &:hover {
-    background-color: #c9302c;
-  }
-}
-
-.deleteAllButton {
-  background-color: #a94442;
-  color: white;
-  border: none;
-  padding: 6px 14px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-weight: bold;
-
-  &:hover {
-    background-color: #843534;
-  }
-}
-
-.filterArea {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 8px 12px;
-  background-color: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-
-  label {
-    font-weight: 600;
-    color: #374151;
+@media (max-width: 768px) {
+  .table {
+    display: none;
   }
 
-  select {
-    padding: 6px 10px;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
+  .cardRow {
+    display: block;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
     background-color: #fff;
-    color: #111827;
-    font-size: 14px;
-    cursor: pointer;
-    transition: border-color 0.2s ease;
+    transition: box-shadow 0.2s ease;
 
     &:hover {
-      border-color: #9ca3af;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  .cardField {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.3rem 0;
+    font-size: 0.9rem;
+
+    span.label {
+      font-weight: 600;
+      color: #374151;
+      margin-right: 0.5rem;
     }
 
-    &:focus {
-      outline: none;
-      border-color: #3b82f6;
-      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+    span.value {
+      color: #111827;
+      text-align: right;
+      word-break: break-word;
     }
+  }
+
+  .cardDetails {
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+    background-color: #fafafa;
+    border-radius: 6px;
+    white-space: pre-wrap;
+    font-size: 0.85rem;
+    color: #333;
+  }
+
+  .deleteButton,
+  .deleteAllButton {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+}
+
+.mobileCards {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobileCards {
+    display: block;
+  }
+
+  .tableWrapper {
+    display: none;
   }
 }

--- a/src/components/ErrorLogs/ErrorLogs.tsx
+++ b/src/components/ErrorLogs/ErrorLogs.tsx
@@ -22,8 +22,6 @@ export const ErrorLogs = () => {
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>{t("errorLogs")}</h1>
-
-      {/* フィルター */}
       <div className={styles.filterArea}>
         <label htmlFor="filter">{t("filter")}：</label>
         <select
@@ -37,13 +35,10 @@ export const ErrorLogs = () => {
           <option value="info">{t("info")}</option>
         </select>
       </div>
-
-      {/* ログがない場合 */}
       {logs.length === 0 ? (
         <p>{t("notErrorLogs")}</p>
       ) : (
         <>
-          {/* アクションボタン */}
           <div className={styles.actions}>
             <button
               className={styles.deleteAllButton}
@@ -52,8 +47,6 @@ export const ErrorLogs = () => {
               {t("deleteAll")}
             </button>
           </div>
-
-          {/* PC用テーブル表示 */}
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
               <thead>
@@ -104,8 +97,6 @@ export const ErrorLogs = () => {
               </tbody>
             </table>
           </div>
-
-          {/* モバイルカード表示 */}
           <div className={styles.mobileCards}>
             {logs.map((log) => (
               <div key={log.id} className={styles.cardRow}>

--- a/src/components/ErrorLogs/ErrorLogs.tsx
+++ b/src/components/ErrorLogs/ErrorLogs.tsx
@@ -23,13 +23,13 @@ export const ErrorLogs = () => {
     <div className={styles.container}>
       <h1 className={styles.title}>{t("errorLogs")}</h1>
 
+      {/* フィルター */}
       <div className={styles.filterArea}>
         <label htmlFor="filter">{t("filter")}：</label>
         <select
           id="filter"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className={styles.filterSelect}
         >
           <option value="all">{t("all")}</option>
           <option value="error">{t("error")}</option>
@@ -38,10 +38,12 @@ export const ErrorLogs = () => {
         </select>
       </div>
 
+      {/* ログがない場合 */}
       {logs.length === 0 ? (
         <p>{t("notErrorLogs")}</p>
       ) : (
         <>
+          {/* アクションボタン */}
           <div className={styles.actions}>
             <button
               className={styles.deleteAllButton}
@@ -50,55 +52,95 @@ export const ErrorLogs = () => {
               {t("deleteAll")}
             </button>
           </div>
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th>{t("date")}</th>
-                <th>{t("level")}</th>
-                <th>{t("message")}</th>
-                <th>{t("page")}</th>
-                <th>{t("delete")}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {logs.map((log) => (
-                <Fragment key={log.id}>
-                  <tr
-                    key={log.id}
-                    className={styles[`level_${log.level ?? "error"}`]}
-                    onClick={() => toggleDetails(log.id)}
-                  >
-                    <td>
-                      {log.timestamp ? log.timestamp.toLocaleString() : "-"}
-                    </td>
-                    <td>{log.level ?? "error"}</td>
-                    <td>{log.message}</td>
-                    <td>{log.page ?? "-"}</td>
-                    <td>
-                      <button
-                        className={styles.deleteButton}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDeleteLog(log.id);
-                        }}
-                      >
-                        {t("delete")}
-                      </button>
-                    </td>
-                  </tr>
-                  {openId === log.id && (
-                    <tr className={styles.detailsRow}>
-                      <td colSpan={5}>
-                        <pre className={styles.details}>
-                          {log.details ?? t("noDetails")}
-                        </pre>
+
+          {/* PC用テーブル表示 */}
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>{t("date")}</th>
+                  <th>{t("level")}</th>
+                  <th>{t("message")}</th>
+                  <th>{t("page")}</th>
+                  <th>{t("delete")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log) => (
+                  <Fragment key={log.id}>
+                    <tr
+                      className={styles[`level_${log.level ?? "error"}`]}
+                      onClick={() => toggleDetails(log.id)}
+                    >
+                      <td>
+                        {log.timestamp ? log.timestamp.toLocaleString() : "-"}
+                      </td>
+                      <td>{log.level ?? "error"}</td>
+                      <td>{log.message}</td>
+                      <td>{log.page ?? "-"}</td>
+                      <td>
+                        <button
+                          className={styles.deleteButton}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeleteLog(log.id);
+                          }}
+                        >
+                          {t("delete")}
+                        </button>
                       </td>
                     </tr>
-                  )}
-                </Fragment>
-              ))}
-            </tbody>
-          </table>
+                    {openId === log.id && (
+                      <tr className={`${styles.detailsRow} open`}>
+                        <td colSpan={5}>
+                          <pre className={styles.details}>
+                            {log.details ?? t("noDetails")}
+                          </pre>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* モバイルカード表示 */}
+          <div className={styles.mobileCards}>
+            {logs.map((log) => (
+              <div key={log.id} className={styles.cardRow}>
+                <div className={styles.cardField}>
+                  <span className="label">{t("date")}:</span>
+                  <span className="value">
+                    {log.timestamp ? log.timestamp.toLocaleString() : "-"}
+                  </span>
+                </div>
+                <div className={styles.cardField}>
+                  <span className="label">{t("level")}:</span>
+                  <span className="value">{log.level ?? "error"}</span>
+                </div>
+                <div className={styles.cardField}>
+                  <span className="label">{t("message")}:</span>
+                  <span className="value">{log.message}</span>
+                </div>
+                <div className={styles.cardField}>
+                  <span className="label">{t("page")}:</span>
+                  <span className="value">{log.page ?? "-"}</span>
+                </div>
+
+                {openId === log.id && log.details && (
+                  <div className={styles.cardDetails}>{log.details}</div>
+                )}
+
+                <button
+                  className={styles.deleteButton}
+                  onClick={() => handleDeleteLog(log.id)}
+                >
+                  {t("delete")}
+                </button>
+              </div>
+            ))}
+          </div>
         </>
       )}
     </div>

--- a/src/components/ErrorLogs/__tests__/ErrorLogs.test.tsx
+++ b/src/components/ErrorLogs/__tests__/ErrorLogs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ErrorLogs } from "../ErrorLogs";
 
@@ -51,7 +51,7 @@ describe("ErrorLogs コンポーネント", () => {
     });
 
     render(<ErrorLogs />);
-    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+    expect(screen.getAllByText("読み込み中...")[0]).toBeInTheDocument();
   });
 
   it("ログがない場合はメッセージを表示する", () => {
@@ -67,7 +67,9 @@ describe("ErrorLogs コンポーネント", () => {
     });
 
     render(<ErrorLogs />);
-    expect(screen.getByText("エラーログ一覧")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "エラーログ一覧" })
+    ).toBeInTheDocument();
     expect(screen.getByText("エラーログはありません")).toBeInTheDocument();
   });
 
@@ -113,8 +115,8 @@ describe("ErrorLogs コンポーネント", () => {
     fireEvent.click(deleteButton);
     expect(handleDeleteLogMock).toHaveBeenCalledWith("1");
 
-    const firstRow = screen.getByText("エラー1").closest("tr")!;
-    fireEvent.click(firstRow);
+    const firstRowCell = screen.getAllByText("エラー1")[0].closest("tr")!;
+    fireEvent.click(firstRowCell);
     expect(toggleDetailsMock).toHaveBeenCalledWith("1");
   });
 
@@ -140,7 +142,9 @@ describe("ErrorLogs コンポーネント", () => {
     });
 
     render(<ErrorLogs />);
-    expect(screen.getByText("詳細1")).toBeInTheDocument();
+
+    const detailsElements = screen.getAllByText("詳細1");
+    expect(detailsElements[0]).toBeInTheDocument();
   });
 
   it("details がない場合は '詳細なし' を表示する", () => {

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -2,6 +2,12 @@
   background-color: #fff;
   border-bottom: 1px solid #eee;
   padding: 1rem 2rem;
+  position: relative;
+  z-index: 1000;
+
+  @media (max-width: 768px) {
+    padding: 0.8rem 1.2rem;
+  }
 }
 
 .inner {
@@ -15,14 +21,24 @@
   font-size: 1.4rem;
   color: #333;
   text-decoration: none;
+
+  @media (max-width: 768px) {
+    font-size: 1.2rem;
+  }
 }
 
+/* PCナビ */
 .nav {
   display: flex;
   gap: 1rem;
   align-items: center;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
 }
 
+/* 共通リンク */
 .link {
   color: #333;
   text-decoration: none;
@@ -39,6 +55,7 @@
   border-radius: 4px;
   text-decoration: none;
   font-weight: 500;
+
   &:hover {
     background-color: #0059c1;
   }
@@ -51,6 +68,7 @@
   padding: 0.4rem 1rem;
   border-radius: 4px;
   cursor: pointer;
+
   &:hover {
     background-color: #fee;
   }
@@ -61,13 +79,122 @@
   color: #888;
 }
 
+.menuButton {
+  display: none;
+  position: relative;
+  width: 32px;
+  height: 24px;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+  z-index: 1200; // メニューより前面に出す
+
+  span {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background-color: #333;
+    border-radius: 2px;
+    transition: all 0.3s ease-in-out;
+  }
+
+  span:nth-child(1) {
+    top: 0;
+  }
+  span:nth-child(2) {
+    top: 10px;
+  }
+  span:nth-child(3) {
+    top: 20px;
+  }
+
+  /* ホバー時：少し濃くなる */
+  &:hover span {
+    background-color: #000;
+  }
+
+  /* 開いた状態（アクティブ） */
+  &.active span:nth-child(1) {
+    transform: translateY(10px) rotate(45deg);
+  }
+
+  &.active span:nth-child(2) {
+    opacity: 0;
+  }
+
+  &.active span:nth-child(3) {
+    transform: translateY(-10px) rotate(-45deg);
+  }
+
+  @media (max-width: 768px) {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+/* スライドインメニュー */
+.mobileNav {
+  position: fixed;
+  top: 0;
+  right: -280px;
+  width: 260px;
+  height: 100%;
+  background-color: #fff;
+  box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);
+  transition: right 0.3s ease-in-out;
+  z-index: 999;
+
+  &.open {
+    right: 0;
+  }
+
+  .mobileNavInner {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 1.5rem;
+    gap: 1rem;
+
+    a,
+    button {
+      font-size: 1rem;
+      color: #333;
+      text-decoration: none;
+      background: none;
+      border: none;
+      text-align: left;
+      font-weight: 500;
+      cursor: pointer;
+      padding: 0.5rem 0;
+
+      &:hover {
+        opacity: 0.7;
+      }
+    }
+  }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 998;
+
+  &.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .languageSwitcher {
   display: flex;
   gap: 12px;
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 10;
+  align-items: center;
 
   .languageLink,
   .activeLanguage {
@@ -91,15 +218,26 @@
     color: white;
   }
 
-  @media (max-width: 600px) {
-    flex-direction: column;
-    top: 12px;
-    right: 12px;
+  @media (max-width: 768px) {
+    display: none; /* モバイル時は非表示（モバイルメニューに表示） */
+  }
+}
+
+/* モバイル用言語切り替え */
+.mobileLanguage {
+  margin-top: 2rem;
+  border-top: 1px solid #eee;
+  padding-top: 1rem;
+
+  .languageSwitcher {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    justify-content: center;
 
     .languageLink,
     .activeLanguage {
       padding: 8px 12px;
-      text-align: center;
     }
   }
 }

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -27,7 +27,6 @@
   }
 }
 
-/* PCナビ */
 .nav {
   display: flex;
   gap: 1rem;
@@ -38,7 +37,6 @@
   }
 }
 
-/* 共通リンク */
 .link {
   color: #333;
   text-decoration: none;
@@ -86,7 +84,7 @@
   height: 24px;
   cursor: pointer;
   transition: transform 0.3s ease;
-  z-index: 1200; // メニューより前面に出す
+  z-index: 1200;
 
   span {
     position: absolute;
@@ -108,12 +106,10 @@
     top: 20px;
   }
 
-  /* ホバー時：少し濃くなる */
   &:hover span {
     background-color: #000;
   }
 
-  /* 開いた状態（アクティブ） */
   &.active span:nth-child(1) {
     transform: translateY(10px) rotate(45deg);
   }
@@ -132,7 +128,7 @@
     justify-content: center;
   }
 }
-/* スライドインメニュー */
+
 .mobileNav {
   position: fixed;
   top: 0;
@@ -219,11 +215,10 @@
   }
 
   @media (max-width: 768px) {
-    display: none; /* モバイル時は非表示（モバイルメニューに表示） */
+    display: none;
   }
 }
 
-/* モバイル用言語切り替え */
 .mobileLanguage {
   margin-top: 2rem;
   border-top: 1px solid #eee;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "gatsby";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { LANGUAGES } from "../../constants";
@@ -17,59 +17,99 @@ export const Header: React.FC = () => {
     loading,
   } = useHeader();
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const NavLinks = () => (
+    <>
+      {loading ? (
+        <span className={styles.loading}>{t("loading")}</span>
+      ) : isAuthenticated ? (
+        <>
+          <Link to="/dashboard" className={styles.link}>
+            {t("dashboard")}
+          </Link>
+          <Link to="/posts" className={styles.link}>
+            {t("posts")}
+          </Link>
+          <Link to="/error-logs" className={styles.link}>
+            {t("errorLogs")}
+          </Link>
+          <Link to="/settings" className={styles.link}>
+            {t("settings")}
+          </Link>
+          <button onClick={handleLogout} className={styles.logoutButton}>
+            {t("logout")}
+          </button>
+        </>
+      ) : (
+        <>
+          <Link to="/login" className={styles.link}>
+            {t("login")}
+          </Link>
+          <Link to="/signup" className={styles.button}>
+            {t("resister")}
+          </Link>
+        </>
+      )}
+    </>
+  );
+
+  const LanguageSwitcher = () => (
+    <div className={styles.languageSwitcher}>
+      {languages.map((lng) => {
+        const path = getPathForLanguage(lng);
+        const isActive = lng === language;
+
+        return isActive ? (
+          <span key={lng} className={styles.activeLanguage}>
+            {lng.toUpperCase()}
+          </span>
+        ) : (
+          <Link key={lng} to={path} className={styles.languageLink}>
+            {lng.toUpperCase()}
+          </Link>
+        );
+      })}
+    </div>
+  );
+
   return (
     <header className={styles.header}>
       <div className={styles.inner}>
         <Link to="/" className={styles.logo}>
           {t("home")}
         </Link>
-        <nav className={styles.nav}>
-          {loading ? (
-            <span className={styles.loading}>{t("loading")}</span>
-          ) : isAuthenticated ? (
-            <>
-              <Link to="/dashboard" className={styles.link}>
-                {t("dashboard")}
-              </Link>
-              <Link to="/posts" className={styles.link}>
-                {t("posts")}
-              </Link>
-              <Link to="/error-logs" className={styles.link}>
-                {t("errorLogs")}
-              </Link>
-              <Link to="/settings" className={styles.link}>
-                {t("settings")}
-              </Link>
-              <button onClick={handleLogout} className={styles.logoutButton}>
-                {t("logout")}
-              </button>
-            </>
-          ) : (
-            <>
-              <Link to="/login" className={styles.link}>
-                {t("login")}
-              </Link>
-              <Link to="/signup" className={styles.button}>
-                新規登録
-              </Link>
-            </>
-          )}
-        </nav>
-        <div className={styles.languageSwitcher}>
-          {languages.map((lng) => {
-            const path = getPathForLanguage(lng);
-            const isActive = lng === language;
 
-            return isActive ? (
-              <span key={lng} className={styles.activeLanguage}>
-                {lng.toUpperCase()}
-              </span>
-            ) : (
-              <Link key={lng} to={path} className={styles.languageLink}>
-                {lng.toUpperCase()}
-              </Link>
-            );
-          })}
+        {/* 通常ナビ */}
+        <nav className={styles.nav}>
+          <NavLinks />
+          <LanguageSwitcher />
+        </nav>
+
+        {/* ハンバーガーメニュー */}
+        <div
+          className={`${styles.menuButton} ${menuOpen ? styles.active : ""}`}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+
+      {/* オーバーレイ */}
+      <div
+        className={`${styles.overlay} ${menuOpen ? styles.open : ""}`}
+        onClick={() => setMenuOpen(false)}
+      ></div>
+
+      {/* モバイルメニュー */}
+      <div className={`${styles.mobileNav} ${menuOpen ? styles.open : ""}`}>
+        <div className={styles.mobileNavInner}>
+          <NavLinks />
+          <div className={styles.mobileLanguage}>
+            <LanguageSwitcher />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import { Link } from "gatsby";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { LANGUAGES } from "../../constants";
@@ -7,7 +7,7 @@ import { useHeader } from "./hooks";
 
 const languages = [LANGUAGES.JA, LANGUAGES.EN];
 
-export const Header: React.FC = () => {
+export const Header: FC = () => {
   const { t } = useTranslation("common");
   const {
     getPathForLanguage,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -79,14 +79,10 @@ export const Header: FC = () => {
         <Link to="/" className={styles.logo}>
           {t("home")}
         </Link>
-
-        {/* 通常ナビ */}
         <nav className={styles.nav}>
           <NavLinks />
           <LanguageSwitcher />
         </nav>
-
-        {/* ハンバーガーメニュー */}
         <div
           className={`${styles.menuButton} ${menuOpen ? styles.active : ""}`}
           onClick={() => setMenuOpen(!menuOpen)}
@@ -96,14 +92,10 @@ export const Header: FC = () => {
           <span></span>
         </div>
       </div>
-
-      {/* オーバーレイ */}
       <div
         className={`${styles.overlay} ${menuOpen ? styles.open : ""}`}
         onClick={() => setMenuOpen(false)}
       ></div>
-
-      {/* モバイルメニュー */}
       <div className={`${styles.mobileNav} ${menuOpen ? styles.open : ""}`}>
         <div className={styles.mobileNavInner}>
           <NavLinks />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import { FC } from "react";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { LayoutProps } from "./types";
 import { Header } from "../Header";
 import * as styles from "./Layout.module.scss";
 
-export const Layout: React.FC<LayoutProps> = ({ pageTitle, children }) => {
+export const Layout: FC<LayoutProps> = ({ pageTitle, children }) => {
   const { t } = useTranslation("common");
 
   return (

--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Layout } from "../Layout";
@@ -8,7 +8,7 @@ jest.mock("gatsby", () => {
   return {
     __esModule: true,
     ...originalModule,
-    Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    Link: ({ to, children }: { to: string; children: ReactNode }) => (
       <a href={to}>{children}</a>
     ),
   };

--- a/src/components/Layout/__tests__/Layout.test.tsx
+++ b/src/components/Layout/__tests__/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Layout } from "../Layout";
 
@@ -52,13 +52,28 @@ describe("Layoutコンポーネント", () => {
   it("ヘッダーとナビリンクが正しく表示される", () => {
     render(<Layout pageTitle="ページタイトル">本文</Layout>);
 
-    expect(screen.getByText(/My Gatsby Site/)).toBeInTheDocument();
-    expect(screen.getByText("ホーム画面へようこそ")).toHaveAttribute(
-      "href",
-      "/"
-    );
-    expect(screen.getByText("Posts")).toHaveAttribute("href", "/posts");
-    expect(screen.getByText("JA")).toHaveAttribute("href", "/");
+    const homeLink = screen.getByText("ホーム画面へようこそ");
+    expect(homeLink).toHaveAttribute("href", "/");
+
+    const headerNav = screen.getByRole("navigation");
+
+    const dashboardLink = within(headerNav).getByText("Dashboard");
+    expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+
+    const postsLink = within(headerNav).getByText("Posts");
+    expect(postsLink).toHaveAttribute("href", "/posts");
+
+    const errorLogsLink = within(headerNav).getByText("Error Logs");
+    expect(errorLogsLink).toHaveAttribute("href", "/error-logs");
+
+    const settingsLink = within(headerNav).getByText("Settings");
+    expect(settingsLink).toHaveAttribute("href", "/settings");
+
+    const langLink = within(headerNav).getByText("JA");
+    expect(langLink).toHaveAttribute("href", "/");
+
+    const logoutButton = within(headerNav).getByText("Logout");
+    expect(logoutButton).toBeInTheDocument();
   });
 
   it("pageTitle と children が main に表示される", () => {

--- a/src/components/NotFound/__tests__/NotFound.test.tsx
+++ b/src/components/NotFound/__tests__/NotFound.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { NotFound } from "../NotFound";
@@ -8,7 +8,7 @@ jest.mock("gatsby", () => {
   return {
     __esModule: true,
     ...originalModule,
-    Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    Link: ({ to, children }: { to: string; children: ReactNode }) => (
       <a href={to}>{children}</a>
     ),
   };

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import { FC } from "react";
 import { Link } from "gatsby";
 import { PostCardProps } from "./types";
 import * as styles from "./PostCard.module.scss";
 
-export const PostCard: React.FC<PostCardProps> = ({ post }) => {
+export const PostCard: FC<PostCardProps> = ({ post }) => {
   return (
     <article className={styles.postCard}>
       <Link to={`/posts/${post.slug}`} className={styles.title}>

--- a/src/components/PostCard/__tests__/PostCard.test.tsx
+++ b/src/components/PostCard/__tests__/PostCard.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import { PostCard } from "../PostCard";
 import { PostCardProps } from "../types";
@@ -9,7 +9,7 @@ jest.mock("gatsby", () => {
   return {
     __esModule: true,
     ...originalModule,
-    Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    Link: ({ to, children }: { to: string; children: ReactNode }) => (
       <a href={to}>{children}</a>
     ),
   };

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -24,14 +24,17 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
 }
 
 .avatarWrapper {
+  width: 120px;
+  height: 120px;
+  margin-bottom: 0.8rem;
+  display: flex;
+  justify-content: center;
   position: relative;
-  width: 110px;
-  height: 110px;
-  margin-bottom: 0.5rem;
 }
 
 .avatar {
@@ -39,46 +42,72 @@
   height: 100%;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid #e0e0e0;
+  border: 2px solid #ddd;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease;
-}
 
-.avatar:hover {
-  transform: scale(1.03);
+  &:hover {
+    transform: scale(1.03);
+  }
 }
 
 .avatarPlaceholder {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background: #f2f2f2;
+  background: #f0f0f0;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #999;
+  color: #888;
   font-size: 0.9rem;
   border: 2px dashed #ddd;
 }
 
-.uploadButton {
-  background-color: #555;
-  color: white;
+.avatarActions {
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.uploadButton,
+.deleteButton {
   font-size: 0.9rem;
-  padding: 0.4rem 0.9rem;
-  border: none;
+  padding: 0.4rem 0.8rem;
   border-radius: 6px;
+  border: none;
   cursor: pointer;
-  transition: background-color 0.2s;
+  font-weight: 600;
+  transition: background-color 0.2s ease;
 }
 
-.uploadButton:hover {
-  background-color: #333;
+.uploadButton {
+  background-color: #4a90e2;
+  color: #fff;
+
+  &:hover {
+    background-color: #357ab8;
+  }
+
+  &:disabled {
+    background-color: #9bbce0;
+    cursor: not-allowed;
+  }
 }
 
-.uploadButton:disabled {
-  background-color: #999;
-  cursor: not-allowed;
+.deleteButton {
+  background-color: #e24a4a;
+  color: #fff;
+
+  &:hover {
+    background-color: #c63c3c;
+  }
+
+  &:disabled {
+    background-color: #f39c9c;
+    cursor: not-allowed;
+  }
 }
 
 .hiddenInput {
@@ -97,6 +126,14 @@
   border-radius: 6px;
   font-size: 1rem;
   margin-top: 0.3rem;
+  width: 100%;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #4a90e2;
+    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
+  }
 }
 
 .button {
@@ -107,28 +144,31 @@
   border: none;
   border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #357ab8;
+  }
+
+  &:disabled {
+    background-color: #9bbce0;
+    cursor: not-allowed;
+  }
 }
 
-.button:hover {
-  background-color: #3a7bd5;
-}
-
-.button:disabled {
-  background-color: #9bbce0;
-  cursor: not-allowed;
+.success,
+.error {
+  text-align: center;
+  margin-top: 1rem;
+  font-weight: 500;
 }
 
 .success {
   color: #2e7d32;
-  margin-top: 1rem;
-  text-align: center;
 }
 
 .error {
   color: #c62828;
-  margin-top: 1rem;
-  text-align: center;
 }
 
 .loading {
@@ -172,63 +212,38 @@
   }
 }
 
-.avatarSection {
-  text-align: center;
-  margin-bottom: 1.5rem;
-}
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem;
+    margin: 1rem auto;
+  }
 
-.avatarWrapper {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-}
+  .avatarWrapper {
+    width: 100px;
+    height: 100px;
+  }
 
-.avatar {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid #ddd;
-}
+  .avatarPlaceholder,
+  .avatar {
+    width: 100px;
+    height: 100px;
+  }
 
-.avatarPlaceholder {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  background: #f0f0f0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #888;
-  font-size: 0.9rem;
-}
+  .form {
+    gap: 1rem;
+  }
 
-.avatarActions {
-  display: flex;
-  justify-content: center;
-  gap: 0.8rem;
-}
+  .uploadButton,
+  .deleteButton {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.85rem;
+  }
 
-.uploadButton,
-.deleteButton {
-  background-color: #4a90e2;
-  color: white;
-  font-weight: 600;
-  padding: 0.4rem 0.8rem;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
+  .input {
+    font-size: 0.95rem;
+  }
 
-.uploadButton:hover {
-  background-color: #357ab8;
-}
-
-.deleteButton {
-  background-color: #e24a4a;
-}
-
-.deleteButton:hover {
-  background-color: #c63c3c;
+  .button {
+    padding: 0.5rem 0.8rem;
+  }
 }

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -1,10 +1,11 @@
+import { FC } from "react";
 import { useProfile } from "./hooks";
 import { useTranslation } from "react-i18next";
 import * as styles from "./Profile.module.scss";
 import { PROFILE_STATUS } from "./constants";
 import { DeleteAccount, Notifications, UpdatePassword } from "./components";
 
-export const Profile = () => {
+export const Profile: FC = () => {
   const { t } = useTranslation("common");
   const {
     displayName,

--- a/src/components/Profile/components/DeleteAccount/DeleteAccount.module.scss
+++ b/src/components/Profile/components/DeleteAccount/DeleteAccount.module.scss
@@ -84,3 +84,22 @@
   margin-top: 1rem;
   text-align: center;
 }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .input,
+  .deleteButton {
+    font-size: 0.95rem;
+    padding: 0.65rem 0.9rem;
+  }
+
+  .warning,
+  .error,
+  .success {
+    font-size: 0.9rem;
+    padding: 0.5rem;
+  }
+}

--- a/src/components/Profile/components/DeleteAccount/DeleteAccount.tsx
+++ b/src/components/Profile/components/DeleteAccount/DeleteAccount.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from "react";
+import { FC, FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as styles from "./DeleteAccount.module.scss";
 import { Reauthenticate } from "../../../Reauthenticate";
@@ -6,7 +6,7 @@ import { useAuth } from "../../../../context";
 import { DeleteStatus } from "./types";
 import { DELETE_STATUS } from "./constants";
 
-export const DeleteAccount = () => {
+export const DeleteAccount: FC = () => {
   const { t } = useTranslation("common");
   const { deleteUserAccount } = useAuth();
   const [confirm, setConfirm] = useState("");
@@ -31,7 +31,7 @@ export const DeleteAccount = () => {
       } else {
         setShowReauth(true);
       }
-    } catch (err) {
+    } catch {
       setError(t("deleteAccountFailed"));
       setStatus(DELETE_STATUS.ERROR);
     }

--- a/src/components/Profile/components/Notifications/Notifications.module.scss
+++ b/src/components/Profile/components/Notifications/Notifications.module.scss
@@ -1,40 +1,94 @@
 .container {
-  margin-top: 3rem;
-  padding: 1rem;
-  border: 1px solid #ccc;
-  border-radius: 8px;
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  max-width: 500px;
+  margin-inline: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .title {
-  font-size: 1.2rem;
+  font-size: 1.25rem;
+  font-weight: 600;
   margin-bottom: 1rem;
+  color: #111827;
+  text-align: center;
 }
 
 .toggleGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 }
 
 .toggleLabel {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  font-size: 1rem;
+  color: #374151;
+  cursor: pointer;
+
+  input {
+    width: 18px;
+    height: 18px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    accent-color: #4a90e2;
+    cursor: pointer;
+  }
 }
 
 .saving {
-  color: #999;
+  color: #6b7280;
+  text-align: center;
+  font-size: 0.95rem;
 }
+
 .success {
-  color: green;
+  color: #2e7d32;
+  text-align: center;
+  font-size: 0.95rem;
+  background: #e8f5e9;
+  border: 1px solid #c8e6c9;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
 }
+
 .error {
-  color: red;
+  color: #c62828;
+  text-align: center;
+  font-size: 0.95rem;
+  background: #fdecea;
+  border: 1px solid #f5c6cb;
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .loading {
   text-align: center;
   font-size: 1.1rem;
-  padding: 3rem;
+  padding: 2.5rem;
   color: #555;
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .toggleLabel {
+    font-size: 0.95rem;
+  }
+
+  .success,
+  .error {
+    font-size: 0.9rem;
+    padding: 0.45rem;
+  }
 }

--- a/src/components/Profile/components/Notifications/Notifications.tsx
+++ b/src/components/Profile/components/Notifications/Notifications.tsx
@@ -1,9 +1,10 @@
+import { FC } from "react";
 import { useUserSettings } from "./hooks";
 import { PROFILE_STATUS } from "../../constants";
 import { useTranslation } from "react-i18next";
 import * as styles from "./Notifications.module.scss";
 
-export const Notifications = () => {
+export const Notifications: FC = () => {
   const { t } = useTranslation("common");
   const { settings, updateSetting, loading, status } = useUserSettings();
 
@@ -46,7 +47,6 @@ export const Notifications = () => {
           {t("securityAlerts")}
         </label>
       </div>
-
       {status === PROFILE_STATUS.SAVING && (
         <p className={styles.saving}>{t("saving")}</p>
       )}

--- a/src/components/Profile/components/UpdatePassword/UpdatePassword.module.scss
+++ b/src/components/Profile/components/UpdatePassword/UpdatePassword.module.scss
@@ -27,10 +27,12 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
 
   &:focus {
     border-color: #4a90e2;
     outline: none;
+    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
   }
 }
 
@@ -73,4 +75,21 @@
   padding: 0.75rem;
   margin-top: 1rem;
   text-align: center;
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 1.5rem;
+    margin-top: 2rem;
+  }
+
+  .input {
+    font-size: 0.95rem;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .button {
+    font-size: 0.95rem;
+    padding: 0.7rem;
+  }
 }

--- a/src/components/Profile/components/UpdatePassword/UpdatePassword.tsx
+++ b/src/components/Profile/components/UpdatePassword/UpdatePassword.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FC, FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import * as styles from "./UpdatePassword.module.scss";
 import { Reauthenticate } from "../../../Reauthenticate";
@@ -6,7 +6,7 @@ import { useAuth } from "../../../../context";
 import { ProfileStatus } from "../../types";
 import { PROFILE_STATUS } from "../../constants";
 
-export const UpdatePassword = () => {
+export const UpdatePassword: FC = () => {
   const { t } = useTranslation("common");
   const { updatePasswordSecure } = useAuth();
   const [currentPassword, setCurrentPassword] = useState("");
@@ -15,7 +15,7 @@ export const UpdatePassword = () => {
   const [status, setStatus] = useState<ProfileStatus>(PROFILE_STATUS.IDLE);
   const [error, setError] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
     setStatus(PROFILE_STATUS.SAVING);

--- a/src/components/Seo/Seo.tsx
+++ b/src/components/Seo/Seo.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import { FC } from "react";
 import { Helmet } from "react-helmet";
 import { useStaticQuery, graphql } from "gatsby";
 import { SEOProps } from "./types";
 
-export const SEO: React.FC<SEOProps> = ({
+export const SEO: FC<SEOProps> = ({
   title,
   description,
   image,

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
-import React, {
+import {
   createContext,
+  FC,
   useContext,
   useEffect,
   useRef,
@@ -33,9 +34,7 @@ export const useAuth = (): AuthContextType => {
   return ctx;
 };
 
-export const AuthProvider: React.FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { t } = useTranslation("common");
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -109,5 +109,6 @@
   "warning": "Warning",
   "info": "Info",
   "errorNotificationSettings": "Error Log Notification Settings",
-  "selectErrorLevelsToNotify": "Select the error levels you wish to receive notifications for"
+  "selectErrorLevelsToNotify": "Select the error levels you wish to receive notifications for",
+  "resister": "Resister"
 }

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -109,5 +109,6 @@
   "warning": "警告",
   "info": "情報",
   "errorNotificationSettings": "エラーログ通知設定",
-  "selectErrorLevelsToNotify": "通知を受け取りたいエラーレベルを選択してください"
+  "selectErrorLevelsToNotify": "通知を受け取りたいエラーレベルを選択してください",
+  "resister": "新規登録"
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import { FC } from "react";
 import { PageProps } from "gatsby";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { NotFound, SEO } from "../components";
 import { LANGUAGES, SITE_URL } from "../constants";
 
-const NotFoundPage: React.FC<PageProps> = () => {
+const NotFoundPage: FC<PageProps> = () => {
   const { t, i18n } = useTranslation("common");
 
   const alternateLangs = [

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { FC } from "react";
 import { PrivateRoute } from "@components/PrivateRoute";
 import { Dashboard } from "@components/Dashboard";
 import { Layout } from "@components/Layout";
 import { graphql } from "gatsby";
 
-const DashboardPage: React.FC = () => {
+const DashboardPage: FC = () => {
   return (
     <PrivateRoute>
       <Layout>

--- a/src/pages/error-logs.tsx
+++ b/src/pages/error-logs.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import { FC } from "react";
 import { Layout } from "@components/Layout";
 import { ErrorLogs } from "@components/ErrorLogs/ErrorLogs";
 import { graphql } from "gatsby";
 
-const ErrorLogsPage: React.FC = () => {
+const ErrorLogsPage: FC = () => {
   return (
     <Layout>
       <ErrorLogs />

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { FC } from "react";
 import { PrivateRoute } from "@components/PrivateRoute";
 import { Profile } from "@components/Profile";
 import { graphql } from "gatsby";
 import { Layout } from "@components/Layout";
 
-const SettingsPage: React.FC = () => {
+const SettingsPage: FC = () => {
   return (
     <PrivateRoute>
       <Layout>

--- a/src/templates/HomeTemplate/HomeTemplate.tsx
+++ b/src/templates/HomeTemplate/HomeTemplate.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
+import { FC } from "react";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { graphql } from "gatsby";
 import { Layout, SEO, PrivateRoute } from "../../components";
 import { LANGUAGES, SITE_URL } from "../../constants";
 import * as styles from "./HomeTemplate.module.scss";
 
-const HomeTemplate: React.FC = () => {
+const HomeTemplate: FC = () => {
   const { t, i18n } = useTranslation("common");
 
   const alternateLangs = [

--- a/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
+++ b/src/templates/HomeTemplate/__tests__/HomeTemplate.test.tsx
@@ -1,13 +1,11 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import HomeTemplate from "../HomeTemplate";
 
 jest.mock("../../../components", () => ({
   __esModule: true,
-  Layout: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  Layout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SEO: ({ title, description, pathname }: any) => (
     <div data-testid="seo">
       <span>{title}</span>
@@ -15,9 +13,7 @@ jest.mock("../../../components", () => ({
       <span>{pathname}</span>
     </div>
   ),
-  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  PrivateRoute: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/PostTemplate/PostTemplate.tsx
+++ b/src/templates/PostTemplate/PostTemplate.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FC } from "react";
 import { graphql, PageProps } from "gatsby";
 import { usePostTemplate } from "./hooks";
 import { safeParse, safePlainText } from "./utils";
@@ -10,7 +10,7 @@ import { useTranslation } from "gatsby-plugin-react-i18next";
 import { DiscussionEmbed } from "disqus-react";
 import * as styles from "./PostTemplate.module.scss";
 
-const PostTemplate: React.FC<PageProps<ContentfulPostData>> = ({ data }) => {
+const PostTemplate: FC<PageProps<ContentfulPostData>> = ({ data }) => {
   const { t, i18n } = useTranslation("common");
   const { formStatus, handleSubmit, handleTagClick } = usePostTemplate();
 

--- a/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
+++ b/src/templates/PostTemplate/__tests__/PostTemplate.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PageProps } from "gatsby";
@@ -22,9 +22,7 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post-card">{post.title}</div>,
-  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  PrivateRoute: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/PostTemplate/hooks/usePostTemplate.ts
+++ b/src/templates/PostTemplate/hooks/usePostTemplate.ts
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { FormEvent, useState } from "react";
 import { FORM_STATUS } from "../constants";
 import { FormStatus } from "../types";
 
 export const usePostTemplate = () => {
   const [formStatus, setFormStatus] = useState<FormStatus>(FORM_STATUS.IDLE);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setFormStatus(FORM_STATUS.SUBMITTING);
 

--- a/src/templates/PostsListTemplate/PostsListTemplate.module.scss
+++ b/src/templates/PostsListTemplate/PostsListTemplate.module.scss
@@ -2,19 +2,65 @@
   display: flex;
   gap: 1rem;
   margin-bottom: 1.5rem;
+  flex-wrap: wrap;
 
-  input {
+  input,
+  select {
     flex: 1;
-    padding: 0.5rem;
+    padding: 0.6rem 0.8rem;
     border: 1px solid #ccc;
-    border-radius: 4px;
+    border-radius: 6px;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+    box-sizing: border-box;
   }
 
-  select {
-    padding: 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background: #fff;
+  input:focus,
+  select:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  }
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+
+    input,
+    select {
+      flex: none;
+      width: 100%;
+    }
+  }
+}
+
+.filters select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0.6rem 1rem;
+  font-size: 0.95rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background-color: #ffffff;
+  background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2210%22%20height%3D%227%22%20viewBox%3D%220%200%2010%207%22%20fill%3D%22none%22%20xmlns%3D%22http://www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22M1%201L5%205L9%201%22%20stroke%3D%22%23343A40%22%20stroke-width%3D%222%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.8rem center;
+  background-size: 10px 7px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: #3b82f6;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  }
+
+  @media (max-width: 480px) {
+    width: 100%;
   }
 }
 
@@ -23,16 +69,27 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  align-items: center;
+
+  .tagButton,
+  .activeTag {
+    font-size: 0.85rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 0.35rem;
+    cursor: pointer;
+    border: none;
+    white-space: nowrap;
+
+    transition: background-color 0.25s ease, color 0.25s ease,
+      transform 0.15s ease;
+
+    &:hover {
+      transform: scale(1.05);
+    }
+  }
 
   .tagButton {
     background-color: #f3f4f6;
-    border: none;
-    border-radius: 0.3rem;
-    padding: 0.3rem 0.6rem;
-    cursor: pointer;
-    font-size: 0.85rem;
-    transition: background-color 0.2s ease;
+    color: #374151;
 
     &:hover {
       background-color: #d1d5db;
@@ -62,28 +119,34 @@
 .pagination {
   display: flex;
   justify-content: center;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 0.8rem;
+  margin: 2rem 0;
 
   a,
   span {
-    padding: 0.5rem 0.8rem;
-    border-radius: 4px;
+    display: inline-block;
+    padding: 0.5rem 0.9rem;
+    border-radius: 6px;
     font-size: 0.9rem;
     font-weight: 500;
     text-decoration: none;
-    color: #2563eb;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: all 0.2s ease;
   }
 
-  a:hover {
-    background-color: #2563eb;
-    color: #ffffff;
+  a {
+    color: #2563eb;
+    border: 1px solid #2563eb;
+
+    &:hover {
+      background-color: #2563eb;
+      color: #fff;
+    }
   }
 
   span {
     color: #9ca3af;
     cursor: default;
+    border: 1px solid #e5e7eb;
   }
 }
 
@@ -102,7 +165,7 @@
 
 .relatedList {
   list-style: none;
-  padding-left: 0;
+  padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -116,10 +179,30 @@
 .relatedLink {
   color: #2563eb;
   text-decoration: underline;
-  transition: color 0.2s ease;
+  transition: all 0.2s ease;
 
   &:hover {
     color: #1d4ed8;
     text-decoration: none;
+  }
+}
+
+.posts p {
+  text-align: center;
+  font-size: 1rem;
+  color: #6b7280;
+  padding: 2rem 0;
+}
+
+@media (max-width: 480px) {
+  .filters {
+    input,
+    select {
+      width: 100%;
+    }
+  }
+
+  .tagCloud {
+    justify-content: flex-start;
   }
 }

--- a/src/templates/PostsListTemplate/PostsListTemplate.tsx
+++ b/src/templates/PostsListTemplate/PostsListTemplate.tsx
@@ -134,25 +134,22 @@ const PostsListTemplate: React.FC<
         </div>
 
         <nav className={styles.pagination}>
-          {hasPrev ? (
+          {hasPrev && (
             <Link
               to={prevPage}
               onClick={() => pushEvent("pagination_prev", { page: prevPage })}
             >
-              ← {t("prev")}
+              {t("prev")}
             </Link>
-          ) : (
-            <span />
           )}
-          {hasNext ? (
+
+          {hasNext && (
             <Link
               to={nextPage}
               onClick={() => pushEvent("pagination_next", { page: nextPage })}
             >
-              {t("next")} →
+              {t("next")}
             </Link>
-          ) : (
-            <span />
           )}
         </nav>
 

--- a/src/templates/PostsListTemplate/PostsListTemplate.tsx
+++ b/src/templates/PostsListTemplate/PostsListTemplate.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FC } from "react";
 import { documentToPlainTextString } from "@contentful/rich-text-plain-text-renderer";
 import { PageProps, graphql, Link } from "gatsby";
 import { useTranslation } from "gatsby-plugin-react-i18next";
@@ -8,9 +8,10 @@ import { LANGUAGES, SITE_URL } from "../../constants";
 import { AllContentfulPostQuery, PageContext } from "../../types";
 import * as styles from "./PostsListTemplate.module.scss";
 
-const PostsListTemplate: React.FC<
-  PageProps<AllContentfulPostQuery, PageContext>
-> = ({ data, pageContext }) => {
+const PostsListTemplate: FC<PageProps<AllContentfulPostQuery, PageContext>> = ({
+  data,
+  pageContext,
+}) => {
   const { t, i18n } = useTranslation("common");
   const {
     searchTerm,

--- a/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
+++ b/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
@@ -140,9 +140,9 @@ describe("PostsListTemplate コンポーネント", () => {
 
   it("ページネーションリンクが正しく表示される", () => {
     render(<PostsListTemplate {...mockProps} />);
-    const nextLink = screen.getByText("Next →");
+    const nextLink = screen.getByText("Next");
     expect(nextLink).toHaveAttribute("href", "/posts/2");
-    const prevLink = screen.queryByText("← Prev");
+    const prevLink = screen.queryByText("Prev");
     expect(prevLink).not.toBeInTheDocument();
   });
 

--- a/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
+++ b/src/templates/PostsListTemplate/__tests__/PostsListTemplate.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PageProps } from "gatsby";
@@ -7,9 +7,7 @@ import { AllContentfulPostQuery, PageContext } from "types";
 
 jest.mock("../../../components", () => ({
   __esModule: true,
-  Layout: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  Layout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SEO: ({ title, description, pathname, alternateLangs }: any) => (
     <div data-testid="seo">
       <span>{title}</span>
@@ -24,9 +22,7 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post">{post.title}</div>,
-  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  PrivateRoute: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({

--- a/src/templates/PostsListTemplate/hooks/usePostListTemplate.ts
+++ b/src/templates/PostsListTemplate/hooks/usePostListTemplate.ts
@@ -32,9 +32,10 @@ export const usePostListTemplate = () => {
   };
 
   const handleTagClick = (tag: string) => {
+    const newValue = selectedTag === tag ? "" : tag;
     const event = {
-      target: { value: tag },
-    } as React.ChangeEvent<HTMLSelectElement>;
+      target: { value: newValue },
+    } as ChangeEvent<HTMLSelectElement>;
     handleTagChange(event);
   };
 

--- a/src/templates/TagTemplate/TagTemplate.tsx
+++ b/src/templates/TagTemplate/TagTemplate.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FC } from "react";
 import { PageProps, graphql, Link } from "gatsby";
 import { useTranslation } from "gatsby-plugin-react-i18next";
 import { Layout, SEO, PostCard, PrivateRoute } from "../../components";
@@ -6,9 +6,10 @@ import { LANGUAGES, SITE_URL } from "../../constants";
 import { AllContentfulPostQuery } from "../../types";
 import * as styles from "./TagTemplate.module.scss";
 
-const TagTemplate: React.FC<
-  PageProps<AllContentfulPostQuery, { tag: string }>
-> = ({ data, pageContext }) => {
+const TagTemplate: FC<PageProps<AllContentfulPostQuery, { tag: string }>> = ({
+  data,
+  pageContext,
+}) => {
   const { t, i18n } = useTranslation("common");
   const posts = data?.allContentfulGatsbyBlog?.nodes ?? [];
   const { tag } = pageContext;

--- a/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
+++ b/src/templates/TagTemplate/__tests__/TagTemplate.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PageProps } from "gatsby";
@@ -21,9 +21,7 @@ jest.mock("../../../components", () => ({
     </div>
   ),
   PostCard: ({ post }: any) => <div data-testid="post">{post.title}</div>,
-  PrivateRoute: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
+  PrivateRoute: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 jest.mock("gatsby-plugin-react-i18next", () => ({


### PR DESCRIPTION
やったこと

- 記事一覧ページ
  - 検索ボックスとタグフィルターのスタイルを整備（レスポンシブ対応、フォーカス時のボーダーと影付き）
  - タグクラウドのボタンスタイルを改善（hoverアニメーション、アクティブタグの色付け）
  - 投稿カード表示のグリッドレイアウトを設定（PC / タブレット / モバイル対応）
  - ページネーションのボタンスタイルを改善、1ページ目では「前へ」ボタン非表示に
  - タグボタンのトグル機能実装
  - モバイル表示時の検索欄はみ出しを修正

- エラーログ一覧ページ
  - テーブル表示のスタイルを整備（行 hover, level別色分け）
  - 詳細行（openId）のスタイル調整
  - 削除ボタン・全削除ボタンのスタイル改善
  - フィルターセレクトボックスのスタイル改善（レスポンシブ対応）
  - モバイルでの横スクロールをなくす対応（overflow-x: auto のラッパーを追加）
  - ローディング表示のスタイルとアニメーション追加

- 設定ページ
  - プロフィール設定フォームのスタイル整理
  - アバター表示とアクションボタン（変更・削除）のスタイル整備
  - 入力フォーム・保存ボタンのスタイル改善
  - 保存状態（Saving / Success / Error）表示をカラー付きで明確化
  - 現パスワード、新パスワード入力フォームのスタイル整備
  - モバイルでも横スクロールなしで収まるデザイン
  - 通知設定のチェックボックスのスタイル整理（ラベルと配置）
  - ローディング表示対応
  - 「DELETE」と入力して確認する安全仕様を実装
  - 削除状態（Deleting / Success / Error）の表示スタイル整備